### PR TITLE
RHD-3062 make link property more reliable

### DIFF
--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/integration/PushToORCID.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/integration/PushToORCID.java
@@ -2609,10 +2609,19 @@ public class PushToORCID
             for (String l : links)
             {
                 ResearcherUrl researcherUrl = new ResearcherUrl();
-                researcherUrl.setUrlName(l.split("###")[0]);
+                String[] splittedLink = l.split("###");
                 Url url = new Url();
-                url.setValue(l.split("###").length > 1 ? l.split("###")[1] : l);
-                researcherUrl.setUrl(url);
+				if (splittedLink.length == 2) {
+					researcherUrl
+							.setUrlName(StringUtils.isNotBlank(splittedLink[0]) ? splittedLink[0] : splittedLink[1]);
+	                url.setValue(splittedLink[1]);
+	                researcherUrl.setUrl(url);
+				}
+				else {
+					researcherUrl.setUrlName(l);
+	                url.setValue(l);
+	                researcherUrl.setUrl(url);
+				}
                 researcherUrls.add(researcherUrl);
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<org.hibernate.annotations.version>4.0.2.Final</org.hibernate.annotations.version>
 		<org.hibernate.jpa.version>1.0.1.Final</org.hibernate.jpa.version>
 		
-		<org.jdyna.version>5.14</org.jdyna.version>		
+		<org.jdyna.version>5.15</org.jdyna.version>
 		<it.cilea.ccommons.version>2.5</it.cilea.ccommons.version>
 		
 		<ckan.addon.modules>[5.1-SNAPSHOT,6.0-SNAPSHOT)</ckan.addon.modules>


### PR DESCRIPTION
These changes prevent the user to create a link specifying only the title and not the URL and allow to push to ORCID also links with only the URL and no proper title