### PR TITLE
[RHD-3084][CST-1428] development for configurable submission via metadata

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/AbstractProcessingStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/AbstractProcessingStep.java
@@ -128,6 +128,9 @@ public abstract class AbstractProcessingStep
             HttpServletRequest request, HttpServletResponse response,
             SubmissionInfo subInfo) throws ServletException, IOException,
             SQLException, AuthorizeException;
+    
+    public abstract void doClear(SubmissionInfo subInfo) throws ServletException, IOException,
+        SQLException, AuthorizeException;
 
     /**
      * Return a list of all UI fields which had errors that occurred during the

--- a/dspace-api/src/main/java/org/dspace/submit/step/AccessStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/AccessStep.java
@@ -7,6 +7,14 @@
  */
 package org.dspace.submit.step;
 
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Date;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang.time.DateUtils;
 import org.apache.log4j.Logger;
 import org.dspace.app.util.SubmissionInfo;
@@ -22,12 +30,6 @@ import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.handle.HandleManager;
 import org.dspace.submit.AbstractProcessingStep;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.Date;
 
 
 /**
@@ -305,6 +307,13 @@ public class AccessStep extends AbstractProcessingStep
     {
         return 1;
 
+    }
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/CCLicenseStep.java
@@ -257,5 +257,13 @@ public class CCLicenseStep extends AbstractProcessingStep
     {
 		return 1;
     }
+
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
+    }
    
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/CompleteStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/CompleteStep.java
@@ -15,14 +15,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.log4j.Logger;
-
 import org.dspace.app.util.SubmissionInfo;
-import org.dspace.core.ConfigurationManager;
-import org.dspace.submit.AbstractProcessingStep;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.WorkspaceItem;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.LogManager;
+import org.dspace.submit.AbstractProcessingStep;
 import org.dspace.workflow.WorkflowManager;
 import org.dspace.xmlworkflow.XmlWorkflowManager;
 
@@ -146,5 +145,12 @@ public class CompleteStep extends AbstractProcessingStep
         // that occurs just *before* the final confirmation page!
         // (so it should only be processed once!)
         return 1;
+    }
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
     }
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/DescribeStep.java
@@ -1451,4 +1451,11 @@ public class DescribeStep extends AbstractProcessingStep
         }
 
     }
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/InitialQuestionsStep.java
@@ -19,8 +19,8 @@ import org.dspace.app.util.Util;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
-import org.dspace.content.Metadatum;
 import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
 import org.dspace.content.WorkspaceItem;
 import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
@@ -322,5 +322,12 @@ public class InitialQuestionsStep extends AbstractProcessingStep
                 }
             }
         }
+    }
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
     }
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/LicenseStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/LicenseStep.java
@@ -174,4 +174,12 @@ public class LicenseStep extends AbstractProcessingStep
 
     }
 
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
+    }
+
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/SampleStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/SampleStep.java
@@ -170,4 +170,12 @@ public class SampleStep extends AbstractProcessingStep
         // in most cases, you'll want to just return 1
         return 1;
     }
+
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/SelectCollectionStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/SelectCollectionStep.java
@@ -146,4 +146,11 @@ public class SelectCollectionStep extends AbstractProcessingStep
         // there is always just one page in the "select a collection" step!
         return 1;
     }
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/SkipInitialQuestionsStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/SkipInitialQuestionsStep.java
@@ -61,4 +61,11 @@ public class SkipInitialQuestionsStep extends AbstractProcessingStep
     {
         return 1;
     }
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/StartSubmissionLookupStep.java
@@ -430,5 +430,12 @@ public class StartSubmissionLookupStep extends AbstractProcessingStep
     		}
     	}
     }
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
+    }
     
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/UploadStep.java
@@ -30,6 +30,7 @@ import org.dspace.content.Bundle;
 import org.dspace.content.FormatIdentifier;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
+import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.curate.Curator;
 import org.dspace.submit.AbstractProcessingStep;
@@ -738,4 +739,12 @@ public class UploadStep extends AbstractProcessingStep
         return STATUS_COMPLETE;
     }
 
+	@Override
+	public void doClear(SubmissionInfo subInfo) throws ServletException, IOException, SQLException, AuthorizeException {
+		Item item = subInfo.getSubmissionItem().getItem();
+		Bundle[] bundles = item.getBundles(Constants.DEFAULT_BUNDLE_NAME);
+		for (Bundle b : bundles) {
+			item.removeBundle(b);
+		}
+	}
 }

--- a/dspace-api/src/main/java/org/dspace/submit/step/VerifyStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/VerifyStep.java
@@ -123,4 +123,11 @@ public class VerifyStep extends AbstractProcessingStep
         // always just one page for verify step
         return 1;
     }
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        // NOOP
+    }
 }

--- a/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
+++ b/dspace-jspui/src/main/webapp/submit/edit-metadata.jsp
@@ -1334,6 +1334,17 @@
       boolean required, boolean readonly, List valueList, String label,List<DCInput> children,boolean hasParent)
       throws java.io.IOException
     {
+        
+      boolean isSubmissionType = false;
+      String submissionType = ConfigurationManager.getProperty("submission", "submission.type");
+      String type = item.getMetadata(submissionType);
+      String [] submissionTypeArray = submissionType.split("\\.");
+      if (StringUtils.equals(schema,submissionTypeArray[0]) && StringUtils.equals(element,submissionTypeArray[1]) && 
+                 StringUtils.equals(qualifier,submissionTypeArray[2])){
+         isSubmissionType = true;
+      }
+
+        
       Metadatum[] defaults = item.getMetadata(schema, element, qualifier, Item.ANY);
       StringBuffer sb = new StringBuffer();
       Iterator vals;
@@ -1344,10 +1355,18 @@
         .append(label)
         .append("</label>");
 
-      sb.append("<div class=\"col-md-10\"><div class=\"row col-md-12\"><div class=\"col-md-10\">")
-        .append("<select class=\"form-control\" name=\"")
-        .append(fieldName)
-        .append("\"");
+      if(isSubmissionType){
+               sb.append("<div class=\"col-md-10\"><div class=\"row col-md-12\"><div class=\"col-md-10\">")
+             .append("<select class=\"form-control\" onchange=\"disableStep()\" name=\"")
+             .append(fieldName)
+             .append("\"");
+       }else{
+           sb.append("<div class=\"col-md-10\"><div class=\"row col-md-12\"><div class=\"col-md-10\">")
+             .append("<select class=\"form-control\" name=\"")
+             .append(fieldName)
+             .append("\"");
+       }
+
       if (repeatable)
         sb.append(" size=\"15\"  multiple=\"multiple\"");
       if (readonly)

--- a/dspace-jspui/src/main/webapp/submit/progressbar.jsp
+++ b/dspace-jspui/src/main/webapp/submit/progressbar.jsp
@@ -24,6 +24,8 @@
 <%@ page import="org.dspace.app.webui.servlet.SubmissionController" %>
 <%@ page import="org.dspace.app.webui.submit.JSPStepManager" %>
 <%@ page import="org.dspace.submit.AbstractProcessingStep" %>
+<%@ page import="org.dspace.content.EditItem"%>
+<%@ page import="org.dspace.core.ConfigurationManager"%>
 
 <%@ page import="org.dspace.core.Context" %>
 <%@ page import="org.dspace.content.Collection" %>
@@ -38,6 +40,13 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 
 <%
+
+    Object subType = request.getAttribute("submissionType");
+    String submissionType = null;
+    if (subType != null){
+		submissionType = (String) subType;
+    }
+    
     request.setAttribute("LanguageSwitch", "hide");
 
     /** log4j logger */
@@ -105,8 +114,14 @@
           int stepNum = Integer.parseInt(fields[0]);
 		  int pageNum = Integer.parseInt(fields[1]);
           
+		  
+		  SubmissionStepConfig nextStepConfig = subInfo.getSubmissionConfig().getStep(stepNum);
 		  //if anywhere in last step (i.e. submission is completed), disable EVERYTHING (not allowed to jump back)
-		  if(stepReached >= subConfig.getNumberOfSteps())
+          if(nextStepConfig != null && JSPStepManager.skipStep(nextStepConfig, subInfo) && !(subInfo.getSubmissionItem() instanceof EditItem)){
+          %>
+          <input class="submitProgressButtonCurrent btn btn-default" disabled="disabled" type="submit" name="<%=AbstractProcessingStep.PROGRESS_BAR_PREFIX + stepAndPage%>" value="<%=heading%>" />
+          <%  
+          } else if (stepReached >= subConfig.getNumberOfSteps())
           {
 			 if(stepNum==subConfig.getNumberOfSteps())
 			 {
@@ -161,4 +176,5 @@
 			<fmt:param><%=collection.getName() %></fmt:param>
 		</fmt:message></p>
 </div>
+	<input type="hidden" name="submissionType" value="<%=submissionType%>" />
 </div>

--- a/dspace-jspui/src/main/webapp/utils.js
+++ b/dspace-jspui/src/main/webapp/utils.js
@@ -274,3 +274,12 @@ function itemListCheckAll(checkBoxName){
 		}
 	}
 }
+
+function disableStep(){
+	var cells = document.getElementsByClassName("submitProgressButtonDone"); 
+    for (var i = 0; i < cells.length; i++) { 
+        cells[i].classList.remove("btn-info");
+        cells[i].classList.add("btn-default");
+        cells[i].disabled = true;
+    }
+}

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -35,6 +35,19 @@
    
    
      <page number="1">
+     
+<!--   	 <field>
+       	<dc-schema>local</dc-schema>
+		<dc-element>submission</dc-element>
+		<dc-qualifier>type</dc-qualifier>
+		<parent />
+		<label>Submission type</label>
+		<input-type value-pairs-name="submission_types">dropdown</input-type>
+		<repeatable>false</repeatable>
+		<required />
+		<hint />
+     </field> -->
+     
 	 <!-- entspricht Erfassungsmaske 1 - Eingabe der Basis-Metadaten  -->
 	 <!-- vor Seite 2 Einbindung der Buttons "Metadata with fulltext" and "Metadata without fulltext"; A.G., 29.07.2019  -->
 	 <!-- DC.TITLE  -->
@@ -1533,9 +1546,16 @@
 		</pair>
 	</value-pairs>
 	
-	
-	
-	
+<!--     <value-pairs value-pairs-name="submission_types" dc-term="submission_types">
+      <pair>
+        <displayed-value>only-metadata</displayed-value>
+		<stored-value>only-metadata</stored-value>
+      </pair>
+      <pair>
+        <displayed-value>Full-Text</displayed-value>
+        <stored-value>full-text</stored-value>
+      </pair>
+    </value-pairs> -->
 
  </form-value-pairs>
 

--- a/dspace/config/modules/submission.cfg
+++ b/dspace/config/modules/submission.cfg
@@ -1,0 +1,6 @@
+#submission type metadata
+submission.type = local.submission.type
+
+#The value of the properties is the number of step that you want to do. The relation of number and step is made by item-submission.xml file
+submission.only-metadata = describe|verify|license|complete
+submission.full-text = describe|upload|verify|license|complete

--- a/dspace/config/modules/workflow.cfg
+++ b/dspace/config/modules/workflow.cfg
@@ -14,3 +14,8 @@ workflow.framework=originalworkflow
 #Allow the reviewers to add/edit/remove files from the submission
 #When changing this property you might want to alert submitters in the license that reviewers can alter their files
 reviewer.file-edit=false
+
+#Configuration for skip workflow step
+#workflow.submission.type = local.submission.type
+#workflow.skip.only-metadata = STEP1POOL|STEP1|STEP2POOL|STEP2|STEP3POOL|STEP3
+#workflow.skip.full-text =

--- a/dspace/config/registries/local-types.xml
+++ b/dspace/config/registries/local-types.xml
@@ -39,8 +39,15 @@
 
   <dc-type>
     <schema>local</schema>
+    <element>submission</element>
+    <qualifier>type</qualifier>
+    <scope_note>Usually a dropdown to setup submission progress step</scope_note>
+  </dc-type>
+  
+  <dc-type>
+    <schema>local</schema>
     <element>fakeitem</element>
     <scope_note>Set to true/yes/on to flag the item for deletation upon
 	deposit by the DeleteFakeItem consumer</scope_note>
-  </dc-type>
+  </dc-type>  
 </dspace-dc-types>


### PR DESCRIPTION
This PR address development to configure different steps layout on submission flow.

The default is configured to read content in the "local.submission.type" metadata. If the value of this metadata is configured with "metadata-only" causes the follow steps describe|verify|license|complete otherwise with "full-text" address the follow steps describe|upload|verify|license|complete

In the input-forms.xml, you find an example (I leaving it commented).
