### PR TITLE
[RHD-3083] added Persistent Registration step on submission

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/step/MintIdentifiersStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/MintIdentifiersStep.java
@@ -1,0 +1,154 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.submit.step;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.dspace.app.util.SubmissionInfo;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.identifier.IdentifierException;
+import org.dspace.identifier.IdentifierService;
+import org.dspace.submit.AbstractProcessingStep;
+import org.dspace.utils.DSpace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This step mints the persistent identifiers (handle, doi, ...) an item will
+ * get assigned when entering the repository.
+ * This feature cannot be included in any official release of DSpace as the
+ * JSPUI won't be continued in DSpace 7 and all following minor versions of
+ * DSpace 6 will contain bugfixes only. Therefore we developped this feature
+ * in a way that keeps it as close to the existing code as possible, to keep
+ * minor verison updates as simple as possible.
+ * In JSPUI's JSPStepManager there is a bug. It detects a step as
+ * non-interactive one, by checking if a JSP was called enduring the step's
+ * pre-processing. Non-interactive steps are steps working in the background
+ * of the submission process, no being listed in the progress bar, not calling
+ * any JSPs. Therefore for any step detected as non-inveractive one its
+ * post-processing method is never called.
+ * To keep updates simple we decided to not fix the bug, but to create two
+ * submission steps: one step mints the identifiers without showing any JSP in
+ * the pre-processing. The other one shows identifiers in the preprocessing
+ * without doing anything in the processing and in the post-processing.
+ * This step is the one minting the identifiers.
+ *
+ * @author Pascal-Nicolas Becker (pascal at the dash library dash code dot de)
+ */
+public class MintIdentifiersStep extends AbstractProcessingStep
+{
+
+    private static Logger log = LoggerFactory.getLogger(MintIdentifiersStep.class);
+    /***************************************************************************
+     * STATUS / ERROR FLAGS (returned by doProcessing() if an error occurs or
+     * additional user interaction may be required)
+     * 
+     * (Do NOT use status of 0, since it corresponds to STATUS_COMPLETE flag
+     * defined in the JSPStepManager class)
+     **************************************************************************/
+    public static final int STATUS_NO_ITEM = 1;
+    public static final int STATUS_UNEXPECTED_ERROR = 2;
+    public static final int STATUS_MINTING_ERROR = 3;
+
+    // default constructor, just to add error messages.
+    public MintIdentifiersStep()
+    {
+        super();
+        this.addErrorMessage(STATUS_NO_ITEM,
+                             "The MintIdentifiersStep was unable to obtain any submission item.");
+        this.addErrorMessage(STATUS_UNEXPECTED_ERROR,
+                             "An unexpected Error occured. Check the logfiles for further information.");
+        this.addErrorMessage(STATUS_MINTING_ERROR,
+                             "An error occured while minting the persistent identifiers. Check the log files for further information.");
+    }
+
+    /**
+     * This method calls IdentifierService.reserver(...) that will call the
+     * mint methods of all configured IdentifierServiceProviders, which will
+     * then mint the identifiers.
+     * 
+     * @param context
+     *            current DSpace context
+     * @param request
+     *            current servlet request object
+     * @param response
+     *            current servlet response object
+     * @param subInfo
+     *            submission info object
+     * @return Status or error flag which will be processed by
+     *         doPostProcessing() below! (if STATUS_COMPLETE or 0 is returned,
+     *         no errors occurred!)
+     */
+    public int doProcessing(Context context, HttpServletRequest request,
+            HttpServletResponse response, SubmissionInfo subInfo)
+            throws ServletException, IOException, SQLException,
+            AuthorizeException
+    {
+        // currently it is not possible to write a submission step that does not send any JSP at start of the step, but
+        // only at its end. Therefore we have to write a non-interactive step that does mint the identifiers only and
+        // a second separate stept that does show the previously minted identifiers to the user.
+
+        // get the item
+        Item item = subInfo.getSubmissionItem().getItem();
+        if (item == null)
+        {
+            // this shouldn't happen, catch and log it anyway.
+            log.warn("MintIdentifiersStep called, but no item supplied.");
+            return STATUS_NO_ITEM;
+        }
+
+        // try to get the identifier service
+        IdentifierService identifierService = new DSpace().getSingletonService(IdentifierService.class);
+        try {
+            if (identifierService != null)
+            {
+                // reserving let the identifier service calls mint on all IdentivierServiceProvider.
+                identifierService.reserve(context, item);
+            }
+        } catch (IdentifierException ex) {
+            log.error("Cannot mint identifier.", ex);
+            return STATUS_MINTING_ERROR;
+        }
+
+        // store changes to the item, we do not need to call context.commit here,
+        // it is done by the submission controller.
+        item.update();
+
+        return STATUS_COMPLETE;
+    }
+
+    
+    /**
+     * As this is a non-interactive step we do not have any pages => 0.
+     * 
+     * @return the number of pages in this step
+     */
+    public int getNumberOfPages(HttpServletRequest request,
+            SubmissionInfo subInfo) throws ServletException
+    {
+        /*
+         * If you return 0, this Step will not appear in the Progress Bar at
+         * ALL! Therefore it is important for non-interactive steps to return 0.
+         */
+
+        return 0;
+    }
+
+	@Override
+	public void doClear(SubmissionInfo subInfo) throws ServletException, IOException, SQLException, AuthorizeException {
+		// TODO Auto-generated method stub
+		
+	}
+}

--- a/dspace-api/src/main/java/org/dspace/submit/step/ShowIdentifiersStep.java
+++ b/dspace-api/src/main/java/org/dspace/submit/step/ShowIdentifiersStep.java
@@ -1,0 +1,106 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.submit.step;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.dspace.app.util.SubmissionInfo;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Context;
+import org.dspace.submit.AbstractProcessingStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This step shows previously minted persistent identifiers (handle, doi,
+ * ...) so that an author can include them into his/her files.
+ * This feature cannot be included in any official release of DSpace as the
+ * JSPUI won't be continued in DSpace 7 and all following minor versions of
+ * DSpace 6 will contain bugfixes only. Therefore we developped this feature
+ * in a way that keeps it as close to the existing code as possible, to keep
+ * minor verison updates as simple as possible.
+ * In JSPUI's JSPStepManager there is a bug. It detects a step as
+ * non-interactive one, by checking if a JSP was called enduring the step's
+ * pre-processing. Non-interactive steps are steps working in the background
+ * of the submission process, no being listed in the progress bar, not calling
+ * any JSPs. Therefore for any step detected as non-inveractive one its
+ * post-processing method is never called.
+ * To keep updates simple we decided to not fix the bug, but to create two
+ * submission steps: one step mints the identifiers without showing any JSP in
+ * the pre-processing. The other one shows identifiers in the preprocessing
+ * without doing anything in the processing and in the post-processing.
+ * This step is the one shpwing the previously minted identifiers.
+ *
+ * @author Pascal-Nicolas Becker (pascal at the dash library dash code dot de)
+ */
+public class ShowIdentifiersStep extends AbstractProcessingStep
+{
+
+    private static Logger log = LoggerFactory.getLogger(ShowIdentifiersStep.class);
+
+    /**
+     * This method will run after the pre-processing already displayed the
+     * identifiers. Therefore all we need to do is to mark this step as
+     * completed.
+     * 
+     * @param context
+     *            current DSpace context
+     * @param request
+     *            current servlet request object
+     * @param response
+     *            current servlet response object
+     * @param subInfo
+     *            submission info object
+     * @return Status or error flag which will be processed by
+     *         doPostProcessing() below! (if STATUS_COMPLETE or 0 is returned,
+     *         no errors occurred!)
+     */
+    public int doProcessing(Context context, HttpServletRequest request,
+            HttpServletResponse response, SubmissionInfo subInfo)
+            throws ServletException, IOException, SQLException,
+            AuthorizeException
+    {
+        // currently it is not possible to write a submission step that does not send any JSP at start of the step, but
+        // only at its end. Therefore we have to write a non-interactive step that does mint the identifiers only and
+        // a second separate step that does show the previously minted identifiers to the user. Following that this step
+        // seems to do nothing. Its JSPUI part does show the previously minted identifiers.
+
+        return STATUS_COMPLETE;
+    }
+
+    
+    /**
+     * We show the identifiers on one page => return 1
+     * 
+     * 
+     * @param request
+     *            The HTTP Request
+     * @param subInfo
+     *            The current submission information object
+     * 
+     * @return the number of pages in this step
+     */
+    public int getNumberOfPages(HttpServletRequest request,
+            SubmissionInfo subInfo) throws ServletException
+    {
+        return 1;
+    }
+
+
+    @Override
+    public void doClear(SubmissionInfo subInfo) throws ServletException,
+            IOException, SQLException, AuthorizeException
+    {
+        //NOOP
+    }
+}

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -5243,3 +5243,21 @@ jsp.display-item.createnewversion.button = Create new version
 
 jsp.version.notice.version_unauthorized = Notice
 jsp.version.notice.version_unauthorized_help = You don'have permission to add Fulltext or create a new version. Please contact Administrator.
+
+###################################################################
+# Additions to display persistent identifiers enduring submission #
+###################################################################
+jsp.submit.progressbar.showidentifiers = Persistent Identifiers
+jsp.submit.list-identifiers.title = Persistent Identifiers
+jsp.submit.list-identifiers.no_identifier-service = No supported persistent identifiers
+jsp.submit.list-identifiers.info = Supported identifier(s)
+jsp.submit.list-identifiers.no_doi_found = No assigned DOI found
+jsp.submit.list-identifiers.no_handle_found = No assigned HANDLE found
+jsp.submit.list-identifiers.doi = DOI:
+jsp.submit.list-identifiers.handle = Handle:
+jsp.submit.list-identifiers.other_identifiers = Other identifiers:
+jsp.submit.list-identifiers.no_identifiers_found = No assigned OTHER IDENTIFIERS found
+jsp.submit.list-identifiers.info2 = The identifiers are only minted, at end of the process you will be alerting on the activation.
+jsp.submit.review.identifiers.doi = DOI
+jsp.submit.review.identifiers.handle = Handle
+jsp.submit.review.identifiers.other_identifiers = Other Persistent Identifier

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPShowIdentifiersStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPShowIdentifiersStep.java
@@ -1,0 +1,220 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.webui.submit.step;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.dspace.app.util.SubmissionInfo;
+import org.dspace.app.webui.submit.JSPStep;
+import org.dspace.app.webui.submit.JSPStepManager;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.handle.HandleManager;
+import org.dspace.identifier.DOI;
+import org.dspace.identifier.Handle;
+import org.dspace.identifier.IdentifierService;
+import org.dspace.utils.DSpace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This step shows previously minted persistend identifiers enduring the
+ * submission of a new item.
+ *
+ * @See org.dspace.submit.step.ShowIdentifiersStep
+ * @see org.dspace.submit.step.MintIdentifiersStep
+ *
+ * @author Pascal-Nicolas Becker (pascal at the dash library dash code dot de)
+ */
+public class JSPShowIdentifiersStep extends JSPStep
+{
+    /** JSP which displays the step to the user * */
+    private static final String LIST_IDENTIFIER_JSP = "/submit/list-identifiers.jsp";
+    /** JSP that lists the persistend identifier as part of the very step. */
+    private static final String REVIEW_JSP = "/submit/review-identifiers.jsp";
+
+    private static Logger log = LoggerFactory.getLogger(JSPShowIdentifiersStep.class);
+
+    /**
+     * Load and present previously minted identifiers.
+     * 
+     * @param context
+     *            current DSpace context
+     * @param request
+     *            current servlet request object
+     * @param response
+     *            current servlet response object
+     * @param subInfo
+     *            submission info object
+     */
+    public void doPreProcessing(Context context, HttpServletRequest request,
+            HttpServletResponse response, SubmissionInfo subInfo)
+            throws ServletException, IOException, SQLException,
+            AuthorizeException
+    {
+        // get the item
+        Item item = subInfo.getSubmissionItem().getItem();
+        if (item == null)
+        {
+            // this should never happen. Catch and log it to prevent possible NullPointerException.
+            log.warn("JSPShowIdentifiersStep called, but no item supplied.");
+            throw new IllegalStateException("JSPShowIdentifiersStep called, but no item supplied.");
+        }
+
+        // We'd like to configure if DOIs, Handles, other identifiers or any combination of these should be shown.
+        // Therefore we'll to load dois, handles and other identifiers separately.
+        String doi = null;
+        String handle = null;
+        List<String> otherIdentifiers = new LinkedList<String>();
+
+        // retrieve the identifierService to load available identifierss
+        IdentifierService identifierService = new DSpace().getSingletonService(IdentifierService.class);
+        if (identifierService == null)
+        {
+            // the identifierService seems not to be initialized correctly. Log a warning and set errormessage
+            log.warn("We were unable to load the identifier service. Please check your configuration.");
+            request.setAttribute("errormessage", "jsp.submit.list-identifiers.no_identifier-service");
+            return;
+        }
+
+        // load handle
+        try
+        {
+            handle = identifierService.lookup(context, item, Handle.class);
+        }
+        catch (Exception ex)
+        {
+            // Some exception accured while fetching the handle. We cannot do anything but log it
+            log.error("The following exception accured while we tried to fetch the handle:", ex);
+        }
+
+        // load DOI
+        try
+        {
+            doi = identifierService.lookup(context, item, DOI.class);
+        }
+        catch (Exception ex)
+        {
+            // Some exception accured while fetching the handle. We cannot do anything but log it
+            log.error("The following exception accured while we tried to fetch the handle:", ex);
+        }
+
+        // load everything we haven't loaded yet
+        for (String identifier : identifierService.lookup(context, item))
+        {
+            if (! StringUtils.equals(handle, identifier) && ! StringUtils.equals(doi, identifier))
+            {
+                otherIdentifiers.add(identifier);
+            }
+        }
+
+        // format doi and handle, if we got any. Don't do this before we compared them to possible other identifiers.
+        if (!StringUtils.isEmpty(doi))
+        {
+            // remove the 'doi:' prefix
+            if (StringUtils.startsWithIgnoreCase(doi, DOI.SCHEME))
+            {
+                doi = doi.substring(DOI.SCHEME.length());
+            }
+            // add the doi resolver
+            doi = "https://doi.org/" + doi;
+        }
+        if (!StringUtils.isEmpty(handle))
+        {
+            handle = HandleManager.getCanonicalForm(handle);
+        }
+
+
+        // store loaded identifiers in the request
+        request.setAttribute("doi", doi);
+        request.setAttribute("handle", handle);
+        request.setAttribute("other_identifiers", otherIdentifiers);
+
+        if (doi == null && handle == null && otherIdentifiers.isEmpty())
+        {
+            // no identifiers found. log an error and set an errormessage to present on the jsp.
+            log.error("Unable to find any identifiers assigned to item {}. Did you implemented the MintIdentifierStep " +
+                              "into the submission process?", item.getID());
+            request.setAttribute("errormessage", "jsp.submit.list-identifiers.no_identifiers_found");
+        }
+
+        // load the JSP to present the identifiers.
+        JSPStepManager.showJSP(request, response, subInfo, LIST_IDENTIFIER_JSP);
+    }
+
+    /**
+     * This step only present the identifiers. Therefore we do not have any processiong nor any post-processing.
+     *
+     * @param context
+     *            current DSpace context
+     * @param request
+     *            current servlet request object
+     * @param response
+     *            current servlet response object
+     * @param subInfo
+     *            submission info object
+     * @param status
+     *            any status/errors reported by doProcessing() method
+     */
+    public void doPostProcessing(Context context, HttpServletRequest request,
+            HttpServletResponse response, SubmissionInfo subInfo, int status)
+            throws ServletException, IOException, SQLException,
+            AuthorizeException
+    {
+        // nothing to do.
+    }
+
+    /**
+     * We show one page listing all identifiers assigned to the item.
+     * 
+     * @param request
+     *            The HTTP Request
+     * @param subInfo
+     *            The current submission information object
+     * 
+     * @return the number of pages in this step
+     */
+    public int getNumberOfPages(HttpServletRequest request,
+            SubmissionInfo subInfo) throws ServletException
+    {
+        return 1;
+    }
+    
+    /**
+     * Return the URL path (e.g. /submit/review-metadata.jsp) of the JSP
+     * which will review the information that was gathered in this Step.
+     * <P>
+     * This Review JSP is loaded by the 'Verify' Step, in order to dynamically
+     * generate a submission verification page consisting of the information
+     * gathered in all the enabled submission steps.
+     * 
+     * @param context
+     *            current DSpace context
+     * @param request
+     *            current servlet request object
+     * @param response
+     *            current servlet response object
+     * @param subInfo
+     *            submission info object
+     */
+    public String getReviewJSP(Context context, HttpServletRequest request,
+            HttpServletResponse response, SubmissionInfo subInfo)
+    {
+        return REVIEW_JSP;
+    }
+    
+}

--- a/dspace-jspui/src/main/webapp/submit/list-identifiers.jsp
+++ b/dspace-jspui/src/main/webapp/submit/list-identifiers.jsp
@@ -1,0 +1,169 @@
+<%--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+--%>
+<%--
+  list identifiers minted by the MintIdentifierStep. Listing persistent identifiers enables submitters to add proposals
+  on how to cite the submission.
+  --%>
+
+<%@ page contentType="text/html;charset=UTF-8" %>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt"
+           prefix="fmt" %>
+
+<%@ page import="javax.servlet.jsp.jstl.fmt.LocaleSupport" %>
+
+<%@ page import="org.dspace.core.Context" %>
+<%@ page import="org.dspace.app.webui.servlet.SubmissionController" %>
+<%@ page import="org.dspace.app.util.SubmissionInfo" %>
+<%@ page import="org.dspace.app.webui.util.UIUtil" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.dspace.submit.AbstractProcessingStep" %>
+<%@ page import="java.util.List" %>
+<%@ page import="org.dspace.core.ConfigurationManager" %>
+<%@ page import="java.util.Iterator" %>
+
+<%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
+
+<%
+    request.setAttribute("LanguageSwitch", "hide");
+
+    // Obtain DSpace context
+    Context context = UIUtil.obtainContext(request);
+
+    //get submission information object
+    SubmissionInfo subInfo = SubmissionController.getSubmissionInfo(context, request);
+
+    String errormessage = StringUtils.trim((String) request.getAttribute("errormessage"));
+    String doi = StringUtils.trim((String) request.getAttribute("doi"));
+    String handle = StringUtils.trim((String) request.getAttribute("handle"));
+    List<String> otherIdentifiers = (List<String>) request.getAttribute("other_identifiers");
+
+    String showIdentifiers = ConfigurationManager.getProperty("webui.submission.list-identifiers");
+    if (StringUtils.isEmpty(showIdentifiers))
+    {
+        showIdentifiers = "all";
+    }
+    boolean showDOIs = false;
+    boolean showHandles = false;
+    boolean showOtherIdentifiers = false;
+    if (StringUtils.containsIgnoreCase(showIdentifiers, "all"))
+    {
+        showDOIs = true;
+        showHandles = true;
+        showOtherIdentifiers = true;
+    } else {
+        if (StringUtils.containsIgnoreCase(showIdentifiers, "doi"))
+        {
+            showDOIs = true;
+        }
+        if (StringUtils.containsIgnoreCase(showIdentifiers, "handle"))
+        {
+            showHandles = true;
+        }
+        if (StringUtils.containsIgnoreCase(showIdentifiers, "other"))
+        {
+            showOtherIdentifiers = true;
+        }
+    }
+
+
+    // store if we listed any identifiers
+    boolean identifierListed = false;
+%>
+
+<dspace:layout style="submission"
+               locbar="off"
+               navbar="off"
+               titlekey="jsp.submit.list-identifiers.title"
+               nocache="true">
+
+    <form action="<%= request.getContextPath() %>/submit" method="post" onkeydown="return disableEnterKey(event);">
+
+        <jsp:include page="/submit/progressbar.jsp"/>
+
+        <h1><fmt:message key="jsp.submit.list-identifiers.title" /></h1>
+        <% if (!StringUtils.isEmpty(errormessage)) { %>
+            <div class="alert alert-warning"><fmt:message key="<%= errormessage%>" /></div>
+        <% } %>
+        <p><fmt:message key="jsp.submit.list-identifiers.info"/></p>
+
+        <% if (showDOIs) { %>
+            <div class="row">
+            <% if (StringUtils.isEmpty(doi)) {%>
+                    <div class="col-sm-12 alert alert-warning"><fmt:message key="jsp.submit.list-identifiers.no_doi_found"/></div>
+                <% } else { %>
+                    <% identifierListed = true; %>
+                    <div class="col-sm-2 col-sm-offset-2"><p><fmt:message key="jsp.submit.list-identifiers.doi"/></p></div>
+                    <div class="col-sm-8"><p><a href="<%= doi %>"><%= doi %></a></p></div>
+                <% } %>
+            </div>
+        <% } %>
+
+        <% if (showHandles) { %>
+        <div class="row">
+            <% if (StringUtils.isEmpty(handle)) {%>
+            <div class="col-sm-12 alert alert-warning"><fmt:message key="jsp.submit.list-identifiers.no_handle_found"/></div>
+            <% } else { %>
+                <% identifierListed = true; %>
+                <div class="col-sm-2 col-sm-offset-2"><p><fmt:message key="jsp.submit.list-identifiers.handle"/></p></div>
+                <div class="col-sm-8"><p><a href="<%= handle %>"><%= handle %></a></p></div>
+            <% } %>
+        </div>
+        <% } %>
+
+        <%-- We show other identifiers if configured and available.
+             We do not show any warning if there are no other identifiers.
+             This enables us to show all identifiers by default. --%>
+        <% if (showOtherIdentifiers && otherIdentifiers != null && !otherIdentifiers.isEmpty()) {%>
+            <div class="row">
+                <% identifierListed = true; %>
+                <div class="metadataFieldLabel col-sm-2 col-sm-offset-2"><p><fmt:message key="jsp.submit.list-identifiers.other_identifiers"/></p></div>
+                <div class="metadataFieldValue col-sm-8"><p><%
+                    Iterator<String> identifiers = otherIdentifiers.iterator();
+                    while (identifiers.hasNext())
+                    {
+                        out.print(identifiers.next());
+                        if (identifiers.hasNext())
+                        {
+                            out.println(", ");
+                        }
+                    }
+                %></p>
+                </div>
+            </div>
+        <% } %>
+
+        <div class="row">
+            <% if (!identifierListed) { %>
+                <div class="alert alert-warning"><fmt:message key="jsp.submit.list-identifiers.no_identifiers_found"/></div>
+            <% } else { %>
+                <div class="alert alert-info"><fmt:message key="jsp.submit.list-identifiers.info2"/></div>
+            <% } %>
+        </div>
+
+        <%-- Hidden fields needed for SubmissionController servlet to know which step is next--%>
+        <%= SubmissionController.getSubmissionParameters(context, request) %>
+
+        <%  //if not first step, show "Previous" button
+            if(!SubmissionController.isFirstStep(request, subInfo))
+            { %>
+        <div class="col-md-6 pull-right btn-group">
+            <input class="btn btn-default col-md-4" type="submit" name="<%=AbstractProcessingStep.PREVIOUS_BUTTON%>" value="<fmt:message key="jsp.submit.general.previous"/>" />
+            <input class="btn btn-default col-md-4" type="submit" name="<%=AbstractProcessingStep.CANCEL_BUTTON%>" value="<fmt:message key="jsp.submit.general.cancel-or-save.button"/>" />
+            <input class="btn btn-primary col-md-4" type="submit" name="<%=AbstractProcessingStep.NEXT_BUTTON%>" value="<fmt:message key="jsp.submit.general.next"/>" />
+
+                    <%  } else { %>
+            <div class="col-md-4 pull-right btn-group">
+                <input class="btn btn-default col-md-6" type="submit" name="<%=AbstractProcessingStep.CANCEL_BUTTON%>" value="<fmt:message key="jsp.submit.general.cancel-or-save.button"/>" />
+                <input class="btn btn-primary col-md-6" type="submit" name="<%=AbstractProcessingStep.NEXT_BUTTON%>" value="<fmt:message key="jsp.submit.general.next"/>" />
+                <%  }  %>
+            </div>
+    </form>
+</dspace:layout>

--- a/dspace-jspui/src/main/webapp/submit/review-identifiers.jsp
+++ b/dspace-jspui/src/main/webapp/submit/review-identifiers.jsp
@@ -1,0 +1,209 @@
+<%--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+--%>
+<%--
+  - Review file upload info
+  -
+  - Parameters to pass in to this page (from review.jsp)
+  -    submission.jump - the step and page number (e.g. stepNum.pageNum) to create a "jump-to" link
+  --%>
+<%@ page contentType="text/html;charset=UTF-8" %>
+
+<%@page import="org.dspace.core.ConfigurationManager"%>
+<%@page import="org.dspace.authorize.AuthorizeManager"%>
+<%@page import="java.util.Date"%>
+<%@page import="org.dspace.authorize.ResourcePolicy"%>
+<%@page import="java.util.List"%>
+<%@ page import="org.dspace.app.webui.servlet.SubmissionController" %>
+<%@ page import="org.dspace.app.util.SubmissionInfo" %>
+<%@ page import="org.dspace.app.webui.util.UIUtil" %>
+<%@ page import="org.dspace.content.Bitstream" %>
+<%@ page import="org.dspace.content.BitstreamFormat" %>
+<%@ page import="org.dspace.content.Item" %>
+<%@ page import="org.dspace.core.Context" %>
+<%@ page import="org.dspace.core.Utils" %>
+
+<%@ page import="javax.servlet.jsp.jstl.fmt.LocaleSupport" %>
+<%@ page import="javax.servlet.jsp.PageContext" %>
+<%@ page import="java.util.LinkedList" %>
+<%@ page import="org.dspace.identifier.IdentifierService" %>
+<%@ page import="org.dspace.utils.DSpace" %>
+<%@ page import="org.dspace.identifier.Handle" %>
+<%@ page import="org.dspace.identifier.DOI" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.dspace.app.webui.submit.JSPStepManager" %>
+<%@ page import="org.dspace.identifier.DOIIdentifierProvider" %>
+<%@ page import="java.util.Iterator" %>
+<%@ page import="org.dspace.handle.HandleManager" %>
+
+
+<%@ taglib uri="http://www.dspace.org/dspace-tags.tld" prefix="dspace" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<%
+    request.setAttribute("LanguageSwitch", "hide");
+
+    // Obtain DSpace context
+    Context context = UIUtil.obtainContext(request);
+
+    //get submission information object
+    SubmissionInfo subInfo = SubmissionController.getSubmissionInfo(context, request);
+
+    // get the item
+    Item item = subInfo.getSubmissionItem().getItem();
+
+    String showIdentifiers = ConfigurationManager.getProperty("webui.submission.list-identifiers");
+    if (StringUtils.isEmpty(showIdentifiers))
+    {
+        showIdentifiers = "all";
+    }
+
+    boolean showDOIs = false;
+    boolean showHandles = false;
+    boolean showOtherIdentifiers = false;
+    if (StringUtils.containsIgnoreCase(showIdentifiers, "all"))
+    {
+        showDOIs =true;
+        showHandles = true;
+        showOtherIdentifiers = true;
+    } else {
+        if (StringUtils.containsIgnoreCase(showIdentifiers, "doi"))
+        {
+            showDOIs = true;
+        }
+        if (StringUtils.containsIgnoreCase(showIdentifiers, "handle"))
+        {
+            showHandles = true;
+        }
+        if (StringUtils.containsIgnoreCase(showIdentifiers, "other"))
+        {
+            showOtherIdentifiers = true;
+        }
+    }
+
+    // We'd like to configure if DOIs, Handles, other identifiers or any combination of these should be shown.
+    // Therefore we'll to load dois, handles and other identifiers separately.
+    String doi = null;
+    String handle = null;
+    List<String> otherIdentifiers = new LinkedList<String>();
+
+    // retrieve the identifierService to load available identifierss
+    IdentifierService identifierService = new DSpace().getSingletonService(IdentifierService.class);
+    if (identifierService != null)
+    {
+        try
+        {
+            if (showHandles)
+            {
+                // load handles
+                handle = identifierService.lookup(context, item, Handle.class);
+            }
+        }
+        catch (Exception ex)
+        {
+            // nothing to do here
+        }
+        try
+        {
+            if (showDOIs)
+            {
+                // load DOIs
+                doi = identifierService.lookup(context, item, DOI.class);
+            }
+        }
+        catch (Exception ex)
+        {
+            // nothing to do here
+        }
+        try
+        {
+            if (showOtherIdentifiers)
+            {
+                for (String identifier : identifierService.lookup(context, item))
+                {
+                    // load everything we haven't loaded yet
+                    if (! StringUtils.equals(handle, identifier) && ! StringUtils.equals(doi, identifier))
+                    {
+                        otherIdentifiers.add(identifier);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // nothing to do here
+        }
+
+        // format doi and handle, if we got any. Don't do this before we compared them to possible other identifiers.
+        if (!StringUtils.isEmpty(doi))
+        {
+            // remove the 'doi:' prefix
+            if (StringUtils.startsWithIgnoreCase(doi, DOI.SCHEME))
+            {
+                doi = doi.substring(DOI.SCHEME.length());
+            }
+            // add the doi resolver
+            doi = "https://doi.org/" + doi;
+        }
+        if (!StringUtils.isEmpty(handle))
+        {
+            handle = HandleManager.getCanonicalForm(handle);
+        }
+    }
+
+    // Did we found any identifiers or shall we print an error message?
+    boolean foundIdentifiers = true;
+    if (StringUtils.isEmpty(doi) && StringUtils.isEmpty(handle) && otherIdentifiers.isEmpty())
+    {
+        foundIdentifiers = false;
+    }
+%>
+
+
+<%-- ====================================================== --%>
+<%--                PERSISTENT IDENTIFIER                   --%>
+<%-- ====================================================== --%>
+
+<div class="col-md-10">
+    <div class="row">
+        <% if (foundIdentifiers) { %>
+            <% if (!StringUtils.isEmpty(doi))
+            { %>
+                <span class="metadataFieldLabel col-md-4"><fmt:message key="jsp.submit.review.identifiers.doi"/></span>
+                <span class="metadataFieldValue col-md-8"><a href="<%= doi %>"><%= doi %></a></span>
+            <%}%>
+
+            <% if (!StringUtils.isEmpty(handle))
+            { %>
+                <span class="metadataFieldLabel col-md-4"><fmt:message key="jsp.submit.review.identifiers.handle"/></span>
+                <span class="metadataFieldValue col-md-8"><a href="<%= handle %>"><%= handle %></a></span>
+            <%}%>
+
+            <% if (otherIdentifiers != null && !otherIdentifiers.isEmpty())
+            { %>
+                <span class="metadataFieldLabel col-md-4"><fmt:message key="jsp.submit.review.identifiers.other_identifiers"/></span>
+                <span class="metadataFieldValue col-md-8">
+                    <%
+                        Iterator<String> identifiers = otherIdentifiers.iterator();
+                        while (identifiers.hasNext())
+                        {
+                            out.print(identifiers.next());
+                            if (identifiers.hasNext())
+                            {
+                                out.println(", ");
+                            }
+                        }
+                    %>
+                </span>
+            <% } %>
+        <% } else { %>
+            <div class="col-md-12 text-center"><fmt:message key="jsp.submit.review.no_identifiers_found"/></div>
+        <% } %>
+    </div>
+</div>

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -2643,3 +2643,11 @@ cookies.policy.enabled = ${cookies.policy.enabled}
 
 #If you want apply the item template after the lookup in dataproviders 
 #bte.applytemplateitem = true
+
+# You can configure which identifiers are shown by adding a configuration property with the key `webui.submission.list-identifiers` to your dspace.cfg.
+# Currently a space-separated list containing any of the following attributes is allowed:
+# * all
+# * handle
+# * doi
+# * other
+webui.submission.list-identifiers = handle,doi,other

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -208,6 +208,24 @@
         <workflow-editable>true</workflow-editable>
       </step>
 
+      <!-- The following two steps should be considered atomic. You should either include both or none.
+           The first one mints persistent identifiers like doi and/or handle. Which persistent identifiers are minted
+           depends on the configuration of DSpace. The second step displays the minted persistent identifiers to the
+           submitter so he/she can include them directory into any uploaded file.
+           Currently it is not possible to write a submission step that does not send any JSP at start of the step, but
+           only at its end. Therefore we had to write two steps: a non-interactive one that does mint the identifiers
+           only and a second separate step that does show the previously minted identifiers to the user. -->
+      <step>
+        <processing-class>org.dspace.submit.step.MintIdentifiersStep</processing-class>
+        <workflow-editable>false</workflow-editable>
+      </step>
+      <step>
+        <heading>submit.progressbar.showidentifiers</heading>
+        <processing-class>org.dspace.submit.step.ShowIdentifiersStep</processing-class>
+        <jspui-binding>org.dspace.app.webui.submit.step.JSPShowIdentifiersStep</jspui-binding>
+        <workflow-editable>true</workflow-editable>
+      </step>
+
        <!--Step 3 will be to Manage Item access.
        <step>
            <heading>submit.progressbar.access</heading>
@@ -263,7 +281,6 @@
       <!--Step 7 will be to Sign off on the License-->
 	  <!-- Standardlizenz auskommentiert; der Sammlung "Open-Access Publikationen" habe ich eine Standardlizenz (vorerst Englisch)
 	  zugeordnet; zu klaeren, ob unterschriebener ausgedruckter VÖ-Vertrag genügt; A.G., 29.05.2018  -->
-	  <!--
       <step>
         <heading>submit.progressbar.license</heading>
         <processing-class>org.dspace.submit.step.LicenseStep</processing-class>
@@ -271,7 +288,6 @@
 		<xmlui-binding>org.dspace.app.xmlui.aspect.submission.submit.LicenseStep</xmlui-binding>
 		<workflow-editable>false</workflow-editable>
       </step>
-	-->
 
      
    </submission-process>

--- a/dspace/config/modules/submission.cfg
+++ b/dspace/config/modules/submission.cfg
@@ -3,4 +3,4 @@ submission.type = local.submission.type
 
 #The value of the properties is the number of step that you want to do. The relation of number and step is made by item-submission.xml file
 submission.only-metadata = describe|verify|license|complete
-submission.full-text = describe|upload|verify|license|complete
+submission.full-text = describe|showidentifiers|upload|verify|license|complete


### PR DESCRIPTION
Added Persistent Identifier step to the submission workflow. 

Based on the work of Pascal-Nicolas Becker from "The Library Code"

More info on 4Science Service Desk (ticket RHD-3083)