### PR TITLE
 [RHD-3199] treeview widget: fix wrong configurator name after refactoring

### DIFF
--- a/dspace/config/spring/jspui/treeview.xml
+++ b/dspace/config/spring/jspui/treeview.xml
@@ -15,17 +15,17 @@
 
     <bean name="tree" class="org.dspace.app.webui.cris.json.tree.TreeHierarchy">
     	<property name="searchService" ref="org.dspace.discovery.SearchService" />
-    	<property name="configurator" ref="configuratorResource"/>
+    	<property name="configurator" ref="treeViewConfigurator"/>
     </bean>
     
     <bean name="resource" class="org.dspace.app.webui.cris.json.tree.TreeResource">
-    	<property name="configurator" ref="configuratorResource"/>
+    	<property name="configurator" ref="treeViewConfigurator"/>
 		<property name="applicationService" ref="applicationService" />
     </bean>
 
 	<bean id="solrServiceTreeNodeRootIndexPlugin"
 		class="org.dspace.app.cris.discovery.tree.TreeViewIndexPlugin">
-		<property name="configurator" ref="configuratorResource"/>
+		<property name="configurator" ref="treeViewConfigurator"/>
 		<property name="applicationService" ref="applicationService" />
 	</bean>
 


### PR DESCRIPTION
Related to RHD-3199 issue