### PR TITLE
CST-2549 ExtraMetadataToKeep manage metadata without qualifier

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/lookup/DSpaceWorkspaceItemOutputGenerator.java
+++ b/dspace-api/src/main/java/org/dspace/submit/lookup/DSpaceWorkspaceItemOutputGenerator.java
@@ -329,10 +329,10 @@ public class DSpaceWorkspaceItemOutputGenerator implements OutputGenerator
 	        	int schemaID = schema.getSchemaID();
 	        	MetadataField foundField = MetadataField.findByElement(context, schemaID, md[1], md[2]);
 	            if(foundField != null) {
-	            
+	            	int range = StringUtils.isNotBlank(md[2])? 3:2;
 		            if (extraMetadataToKeep != null
 		                    && extraMetadataToKeep.contains(StringUtils.join(
-		                            Arrays.copyOfRange(md, 0, 3), ".")))
+		                            Arrays.copyOfRange(md, 0, range), ".")))
 		            {
 		                return true;
 		            }


### PR DESCRIPTION
Fixed the Join of the array of metadata (schema,element,qualifier), in order to mandaga metadata without qualifier