### PR TITLE
Rhd 4361 fixes improvements email unpaywall

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -396,6 +396,6 @@ unpaywall.url = https://api.unpaywall.org/v2/
 unpaywall.apikey = 
 unpaywall.cachetime = 604800
 unpaywall.badge.enabled = true
-submit.import.enabled = true
+unpaywall.submit.import.enabled = true
 #metadata used to store doi
-unpaywall.metadata.doi = dcterms.bibliographicCitation.doi
+unpaywall.metadata.doi = dc.identifier.doi

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -5415,3 +5415,4 @@ jsp.display-item.unpaywall.tooltip = Open PDF on Unpaywall
 jsp.submit.choose-file.unpaywall.title = The system is integrated with Unpaywall to retrieve open access fulltext.
 jsp.submit.choose-file.unpaywall.tooltip = Import fulltext from Unpaywall
 jsp.submit.choose-file.unpaywall.button = Import from
+jsp.submit.choose-file.unpaywall.nofulltext = The best match from Unpaywall does not contain a valid link to the open access fulltext!

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/unpaywall/UnpaywallUtils.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/unpaywall/UnpaywallUtils.java
@@ -7,8 +7,10 @@
  */
 package org.dspace.app.cris.unpaywall;
 
+import org.apache.log4j.Logger;
 import org.dspace.app.cris.unpaywall.model.Unpaywall;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import it.cilea.osd.common.core.TimeStampInfo;
@@ -16,6 +18,9 @@ import it.cilea.osd.common.core.TimeStampInfo;
 public class UnpaywallUtils {
 
     private static final String DOI_DEFAULT_BASEURL = "https://doi.org/";
+    
+    /** log4j logger */
+    private static Logger log = Logger.getLogger(UnpaywallUtils.class);
 
     public static JSONObject convertUnpaywallStringToJson(String source)
     {
@@ -32,7 +37,11 @@ public class UnpaywallUtils {
     	if (obj.isNull("best_oa_location")) return null;
 
     	JSONObject bestOA = obj.getJSONObject("best_oa_location");
-		unpBestOA.setUrl_for_pdf(bestOA.getString("url_for_pdf"));
+    	String url = "";
+    	if(!bestOA.isNull("url_for_pdf")){
+    		url = bestOA.getString("url_for_pdf");			
+		}
+    	unpBestOA.setUrl_for_pdf(url);
         unpBestOA.setHost_type(bestOA.getString("host_type"));
         unpBestOA.setVersion(bestOA.getString("version"));
         unpBestOA.setEvidence(bestOA.getString("evidence"));

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/unpaywall/script/UnpaywallScript.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/unpaywall/script/UnpaywallScript.java
@@ -289,9 +289,15 @@ public class UnpaywallScript {
     }
     
     private static String makeItemListBuilder(List<UnpaywallItem> unpaywallItems) {
+    	Integer notificationLimit = ConfigurationManager.getIntProperty("unpaywall", "mail.item.limit", 25);
         int index = 1;
         StringBuilder stringBuilder = new StringBuilder();
         for (UnpaywallItem unpaywallItem : unpaywallItems) {
+        	if (index > notificationLimit) {
+				stringBuilder.append("The above list shows ").append(notificationLimit).append(" records on a total of ").append(unpaywallItems.size()).append(" /n");
+				break;
+			}
+        	
             String handleLink = ConfigurationManager.getProperty("dspace.url") + "/handle/" + unpaywallItem.getHandle();
             stringBuilder.append(index++).append(". ")
                 .append("DOI: ").append(unpaywallItem.getDoi()).append(" - ")

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/unpaywall/script/UnpaywallScript.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/unpaywall/script/UnpaywallScript.java
@@ -33,6 +33,8 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.dspace.app.cris.service.ApplicationService;
+import org.dspace.app.cris.unpaywall.UnpaywallBestOA;
+import org.dspace.app.cris.unpaywall.UnpaywallRecord;
 import org.dspace.app.cris.unpaywall.UnpaywallService;
 import org.dspace.app.cris.unpaywall.UnpaywallUtils;
 import org.dspace.app.cris.unpaywall.model.Unpaywall;
@@ -231,7 +233,10 @@ public class UnpaywallScript {
             if (itemID != null && StringUtils.isNotBlank(doi)) {
                 Unpaywall unpaywall = applicationService.uniqueByDOIAndItemID(UnpaywallUtils.resolveDoi(doi), itemID);
                 if (unpaywall != null && unpaywall.getJsonRecord() != null) {
-                    unpaywallItems.add(new UnpaywallItem(itemID, handle, doi, authors));
+                	UnpaywallRecord record = UnpaywallUtils.convertStringToUnpaywallRecord(unpaywall.getJsonRecord());
+                	if (record.getUnpaywallBestOA() !=null && StringUtils.isNotBlank(record.getUnpaywallBestOA().getUrl_for_pdf())) {						
+                		unpaywallItems.add(new UnpaywallItem(itemID, handle, doi, authors));
+					}
                 }
             }
         }

--- a/dspace-cris/api/src/main/java/org/dspace/app/cris/unpaywall/script/UnpaywallScript.java
+++ b/dspace-cris/api/src/main/java/org/dspace/app/cris/unpaywall/script/UnpaywallScript.java
@@ -192,6 +192,9 @@ public class UnpaywallScript {
 
             List<String> adminEmails = new ArrayList<>();
             for (EPerson admin : Arrays.asList(Group.allMembers(context, Group.find(context, Group.ADMIN_ID)))) {
+            	if (StringUtils.isBlank(admin.getEmail())) {
+            		continue;
+            	}
                 adminEmails.add(admin.getEmail());
                 mail.addRecipientCC(admin.getEmail());
             }
@@ -251,7 +254,7 @@ public class UnpaywallScript {
                 Unpaywall unpaywall = applicationService.uniqueByDOIAndItemID(UnpaywallUtils.resolveDoi(doi), itemID);
                 if (unpaywall != null && unpaywall.getJsonRecord() != null) {
                 	UnpaywallRecord record = UnpaywallUtils.convertStringToUnpaywallRecord(unpaywall.getJsonRecord());
-                	if (record.getUnpaywallBestOA() !=null && StringUtils.isNotBlank(record.getUnpaywallBestOA().getUrl_for_pdf())) {						
+                	if (record != null && record.getUnpaywallBestOA() !=null && StringUtils.isNotBlank(record.getUnpaywallBestOA().getUrl_for_pdf())) {						
                 		unpaywallItems.add(new UnpaywallItem(itemID, handle, doi, authors));
 					}
                 }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPUploadStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPUploadStep.java
@@ -260,7 +260,6 @@ public class JSPUploadStep extends JSPStep
 
                 return;
             }else {
-            	request.setAttribute("unpaywall_fulltext_found", false);
             	showUploadPage(context, request, response, subInfo, false);
 			}
         }

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPUploadStep.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/submit/step/JSPUploadStep.java
@@ -259,7 +259,10 @@ public class JSPUploadStep extends JSPStep
                         false);
 
                 return;
-            }
+            }else {
+            	request.setAttribute("unpaywall_fulltext_found", false);
+            	showUploadPage(context, request, response, subInfo, false);
+			}
         }
 
         if (buttonPressed.equalsIgnoreCase(UploadStep.SUBMIT_SKIP_BUTTON) ||

--- a/dspace-jspui/src/main/webapp/display-item.jsp
+++ b/dspace-jspui/src/main/webapp/display-item.jsp
@@ -227,7 +227,7 @@ j(document).ready(function() {
 				"doi" : "<%= item.getMetadata(ConfigurationManager.getProperty("unpaywall", "metadata.doi")) %>"
 			},
 			success : function(data) {
-				if(data.isFounded) {
+				if(data.isFounded && data.urlJSON.trim()) {
 					j('div.unpaywall').show();
 					j('#unpaywalljson').attr('href', data.urlJSON);
 				}

--- a/dspace-jspui/src/main/webapp/submit/choose-file.jsp
+++ b/dspace-jspui/src/main/webapp/submit/choose-file.jsp
@@ -59,6 +59,11 @@
     boolean bSherpa = sherpa != null?sherpa:false;
 
     boolean unpaywallEnabled = ConfigurationManager.getBooleanProperty("unpaywall","submit.import.enabled",true);
+    boolean unpaywallFileFound = true;
+    if (request.getAttribute("unpaywall_fulltext_found") != null)
+    {
+    	unpaywallFileFound = (Boolean) request.getAttribute("unpaywall_fulltext_found");
+    }
 %>
 
 
@@ -447,6 +452,11 @@
                 <% if (unpaywallEnabled) { %>
                 <div class="col-lg-12 col-md-4 col-sm-6 unpaywall" hidden>
                     <span><fmt:message key="jsp.submit.choose-file.unpaywall.title"/></span>
+                    <% if(!unpaywallFileFound){ %>
+                    <div class="alert alert-warning" role="alert">
+						<fmt:message key="jsp.submit.choose-file.unpaywall.nofulltext"/>
+					</div>
+				<%	} %> 
                     <div class="media unpaywall">
 	                    <button class="col-lg-12 col-md-4 col-sm-6 unpaywall-button" type="submit" name="submit_unpaywall">
 	                        <span class="metric-counter">

--- a/dspace-jspui/src/main/webapp/submit/choose-file.jsp
+++ b/dspace-jspui/src/main/webapp/submit/choose-file.jsp
@@ -59,11 +59,6 @@
     boolean bSherpa = sherpa != null?sherpa:false;
 
     boolean unpaywallEnabled = ConfigurationManager.getBooleanProperty("unpaywall","submit.import.enabled",true);
-    boolean unpaywallFileFound = true;
-    if (request.getAttribute("unpaywall_fulltext_found") != null)
-    {
-    	unpaywallFileFound = (Boolean) request.getAttribute("unpaywall_fulltext_found");
-    }
 %>
 
 
@@ -95,8 +90,14 @@
                 success : function(data) {
                     if(data.isFounded) {
                         j('div.unpaywall').show();
-                        $('#ajaxUpload').val(false);
-                        $('div.unpaywall').append('<input type="hidden" id="unpaywallUrl" name="unpaywallUrl" value="'+data.urlJSON+'" />');
+                        if(data.urlJSON.trim())
+                        {
+	                        $('#ajaxUpload').val(false);
+	                        $('div.unpaywall').append('<input type="hidden" id="unpaywallUrl" name="unpaywallUrl" value="'+data.urlJSON+'" />');
+                        }else{
+                        	$('.unpaywall-alert').show();
+                        	$('#unpaywall-div').hide();
+                        }
                     }
                 }
             });
@@ -452,12 +453,10 @@
                 <% if (unpaywallEnabled) { %>
                 <div class="col-lg-12 col-md-4 col-sm-6 unpaywall" hidden>
                     <span><fmt:message key="jsp.submit.choose-file.unpaywall.title"/></span>
-                    <% if(!unpaywallFileFound){ %>
-                    <div class="alert alert-warning" role="alert">
+                   	<div class="alert alert-warning unpaywall-alert" role="alert" hidden>
 						<fmt:message key="jsp.submit.choose-file.unpaywall.nofulltext"/>
 					</div>
-				<%	} %> 
-                    <div class="media unpaywall">
+                    <div class="media unpaywall" id="unpaywall-div">
 	                    <button class="col-lg-12 col-md-4 col-sm-6 unpaywall-button" type="submit" name="submit_unpaywall">
 	                        <span class="metric-counter">
 	                            <a id="unpaywalljson" data-toggle="tooltip" target="_blank" style="text-decoration:none" title="<fmt:message key="jsp.submit.choose-file.unpaywall.tooltip"/>">

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -4,6 +4,7 @@
 <input-forms>                    
  <form-map>
    <name-map collection-handle="default" form-name="traditional" />
+   <name-map collection-handle="10.24405/2819" form-name="testsammlung" />
  
  </form-map>
 
@@ -1117,7 +1118,256 @@
 	 
    </form>
 
- 
+   <form name="testsammlung">
+   
+     <page number="1">
+     
+     
+	 <!-- entspricht Erfassungsmaske 1 - Eingabe der Basis-Metadaten  -->
+	 <!-- vor Seite 2 Einbindung der Buttons "Metadata with fulltext" and "Metadata without fulltext"; A.G., 29.07.2019  -->
+	 <!-- DC.TITLE  -->
+	  <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>title</dc-element>
+         <dc-qualifier></dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Titel</label>
+         <input-type>onebox</input-type>
+		 <language value-pairs-name="common_iso_languages">true</language>
+         <hint>Bitte tragen Sie den Haupttitel des Werkes ein.</hint>
+         <required></required>
+       </field>
+	   
+	   
+	   <!-- DC.TITLE.SUBTITLE  -->
+	  <!-- siehe depositonce; A.G.  -->
+	    <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>title</dc-element>
+         <dc-qualifier>subtitle</dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Zusatz zum Titel</label>
+         <input-type>onebox</input-type>
+		 <language value-pairs-name="common_iso_languages">true</language>
+         <hint>Geben Sie hier ggf. den Zusatz zum Haupttitel ein.</hint>
+         <required></required>
+       </field>
+	 
+	 
+	 <!-- ggf. dc.title.alternative; A.G.  -->
+	 
+	 
+	 <!-- DC.LANGUAGE.ISO  -->
+	      <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>language</dc-element>
+         <dc-qualifier>iso</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Sprache</label>
+         <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
+         <hint>Bitte wählen Sie die Originalsprache des Werkes aus. Wenn keine Auswahl zutrifft, nutzen Sie "andere". Wenn der Inhalt nicht wirklich eine Sprache hat, da es sich z.B. um einen Datensatz oder ein Bild handelt, wählen Sie bitte "N/A".</hint>
+	 <required></required>
+       </field>
+	   
+	   
+	   
+	   <!-- DC.DATE.ISSUED -->
+	    <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>date</dc-element>
+         <dc-qualifier>issued</dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Datum der ersten Veröffentlichung</label>
+         <input-type>date</input-type>
+         <hint>Bitte geben Sie das Erstveröffentlichungsdatum an. Der Tag bzw. Monat ist dabei optional.</hint>
+         <required>Bitte geben Sie mindestens das Jahr der Erstveröffentlichung an.</required>
+       </field>
+	   
+	
+	
+	
+	<!-- siehe depositonce; A.G.  -->
+	<!-- die einzelnen MD sind unten  -->
+	<!--
+	 <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>relation</dc-element>
+         <dc-qualifier></dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Relations</label>
+         <input-type value-pairs-name="common_relations">qualdrop_value</input-type>
+         <hint>If the item has any relations to other Objects in openHSU, please enter them here (e.g. the DOI or URL). 
+		 Use the "Reference" relation for connected publications. Use the "Supplement" relation for connected research data.</hint>
+         <required>You must enter at least the year.</required>
+       </field>
+	   -->
+	
+	
+	<!-- DC.RIGHTS.URI  -->
+	<!-- in depositonce für Lizenzen, A.G.  -->
+	<field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>rights</dc-element>
+         <dc-qualifier>uri</dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Lizenz</label>
+         <input-type value-pairs-name="common_licenses">dropdown</input-type>
+         <hint>Bitte wählen Sie eine Lizenz für Ihre Publikation aus. Beispiele siehe https://creativecommons.org/licenses/?lang=de</hint>
+         <required></required>
+     </field>
+	
+	
+	
+	
+	<!-- DC.SUBJECT.DDC  -->
+	<!-- in depositonce für DDC, A.G.  -->
+	<!-- ddc vocabulary in installDir/opt/dspace/config/controlled-vocabularies; ggf. englische Version einbinden; A.G.  -->
+		<field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>subject</dc-element>
+         <dc-qualifier>ddc</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>DDC Klassifikation (genormtes Vokabular)</label>
+         <input-type>onebox</input-type>
+         <hint>Bitte wählen Sie aus der Dewey-Dezimalklassifikation ein oder mehrere Schlagwörter aus.</hint>
+         <required>Sie müssen eine DDC-Klasse eingeben. Beispiele siehe https://www.dnb.de/Substitutes/ddcdeutsch/DE/DDCprodukte/DDCuebersichten/DDCuebersichten_node.html</required>
+		 <vocabulary>ddc</vocabulary>
+     </field>
+	
+	
+	
+	
+
+       <!-- DC.CONTRIBUTOR.AFFILIATION  -->
+           <!-- für Verknüpfung mit dc.contributor.author; A.G.  -->
+             <field>
+                 <dc-schema>dc</dc-schema>
+         <dc-element>contributor</dc-element>
+         <dc-qualifier>affiliation</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Affiliations der Autoren</label>
+         <input-type>onebox</input-type>
+	<parent>dc_contributor_author</parent> 
+        <hint>Bitte geben Sie die Organisationseinheit(en) des / der Autors(en ein. Beispiel: Affiliation "Automatisierungstechnik" (inside the faculty "Maschinenbau"). Wenn der/die Name(n) der Organisationseinheit(en) sich bereits in der Liste befindet/befinden, übernehmen Sie bitte den Datenbank-Eintrag.</hint>
+         <required></required>
+        <visibility></visibility>
+       </field>
+
+
+	   
+	   
+
+	 
+
+	   
+	 <!-- DC.CONTRIBUTOR.AUTHOR  -->
+	 <!-- Wording siehe depositonce; A.G.  -->
+       <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>contributor</dc-element>
+         <dc-qualifier>author</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Autoren</label>
+         <input-type>name</input-type>
+         <hint>Bitte geben Sie die Namen aller Autoren ein. Wenn Namen der Autoren sich bereits in der Liste befinden, übernehmen Sie bitte den Datenbank-Eintrag.</hint>
+	 <required></required>
+       </field>
+
+	   
+	  
+	   
+	   
+	   
+	   
+	   <!-- DC.CONTRIBUTOR.EDITOR  -->
+	   <!-- für Book Part nimmt depositonce noch dcterms.bibliographicCitation.editor; A.G.  -->
+	   <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>contributor</dc-element>
+         <dc-qualifier>editor</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Herausgeber</label>
+         <input-type>name</input-type>
+         <hint>Bitte geben Sie den/die Namen des/der Herausgeber an. Herausgeber können bei Büchern oder Zeitschriftensonderbänden genannt sein. Bei Zeitschriftenbeiträgen wird das Feld in der Regel nicht gefüllt.</hint>
+         <required></required>
+       </field>
+	   
+	   
+	   
+	   <!-- DC.CONTRIBUTOR.OTHER  -->
+	     <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>contributor</dc-element>
+         <dc-qualifier>other</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Sonstige beteiligte Personen</label>
+         <input-type>name</input-type>
+         <hint>Weitere Beteiligte sind Personen, die an der Publikation beteiligt waren, sofern diese auf der Publikation genannt sind. Bsp. Festschrift: die gefeierte Person</hint>
+         <required></required>
+		<visibility></visibility>
+       </field>
+	   
+	   
+	 
+    
+	 <!-- DC.TYPE  -->
+	 <!-- value-pairs-name in depositonce "publication_types" und "research_data_types"; A.G.  -->
+	    <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>type</dc-element>
+         <dc-qualifier></dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Dokumententyp</label>
+         <input-type value-pairs-name="common_types">dropdown</input-type>
+         <hint>Geben Sie an, welche Art von Dokument Sie veröffentlichen, zum Beispiel eine Dissertation oder einen Artikel/Aufsatz. Um mehr als einen Dokumententyp auszuwählen, halten Sie gleichzeitig "STRG" und "Shift".</hint>
+         <required>>Sie müssen mindestens einen Dokumententyp auswählen.</required>
+       </field>
+	   
+	   
+	   
+	   <!-- DC.DESCRIPTION.ABSTRACT  -->
+	   <!-- ggf. mit qualifiern deutsche und andere Abstracts sprachlich kennzeichnen; A.G.  -->
+	     <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>description</dc-element>
+         <dc-qualifier>abstract</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Abstract</label>
+         <input-type>textarea</input-type>
+		 <language value-pairs-name="common_iso_languages">true</language>
+         <hint>Das Abstract hilft anderen, möglichst schnell zu erkennen, worum es in Ihrer Arbeit geht. Wenn Sie das Abstract sowohl in Englisch als auch in Deutsch eingeben, erhöht dies die Wahrscheinlichkeit, dass Ihr Dokument mit deutschen und englischen Suchbegriffen gefunden wird.</hint>
+         <required>Bitte geben Sie ein deutsches und ein englisches Abstract ein. Bitte nutzen Sie "Weitere hinzufügen", wenn Sie Abstracts in weiteren Sprachen eingeben möchten.</required>
+       </field>
+	   
+	   
+	   <!-- DC.DESCRIPTION.SPONSORSHIP  -->
+	   <!-- dc.description.sponsorship ist relevant für die DSpace-DNB-Verbindung; ggf. Organization Units über eigenes MD-Feld nutzen; vgl. TORE  -->
+	      <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>description</dc-element>
+         <dc-qualifier>sponsorship</dc-qualifier>
+         <repeatable>true</repeatable>
+         <label>Sponsors</label>
+         <input-type>onebox</input-type>
+         <hint>Geben Sie die Organisationseinheit ein, an dem die Arbeit angefertigt wurde. Sie können auch mehr als eine Organisationseinheit angeben. Mit dem Button "Weitere eintragen" erzeugen Sie weitere Felder. Das Feld ist ein Pflichtfeld. Für den Fall, dass Sie eine Publikation angeben, die nicht an der HSU verfasst wurde, geben Sie hier als Freitext die Einrichtung an, an der die Publikation verfasst wurde.</hint>
+         <required>Beispiele siehe https://openhsu.ub.hsu-hh.de/simple-searchquery=&amp;location=orgunits</required>
+       </field>
+	   
+	   
+	   <!-- hier wird mit der neuen Version des Submission Workflows die Möglichkeit eingefügt, zu entscheiden, ob "Metadata with fulltext" or "Metadata without fulltext" gemeldet werden sollen; A.G., 29.07.2019  -->
+	         <field>
+		 <dc-schema>dc</dc-schema>
+         <dc-element>identifier</dc-element>
+         <dc-qualifier>doi</dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>DOI</label>
+         <input-type>onebox</input-type>
+         <hint> Fill with the DOI</hint>
+         <required></required>
+       </field>
+	   
+	    </page>
+	</form> 
  </form-definitions>
 
 

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -235,13 +235,6 @@
            <workflow-editable>true</workflow-editable>
        </step>
        -->
-      <!--  Step 3 will be to retrieve openaccess fulltext from Unpaywall -->
-      <step>
-        <heading>submit.progressbar.unpaywall</heading>
-        <processing-class>org.dspace.app.cris.submit.step.UnpaywallStep</processing-class>
-        <workflow-editable>true</workflow-editable>
-      </step>																										
-      
       <!--Step 4 will be to Upload the item -->
       <step>
         <heading>submit.progressbar.upload</heading>
@@ -340,6 +333,12 @@
            <workflow-editable>true</workflow-editable>
        </step>
        -->
+      <!--  Step 3 will be to retrieve openaccess fulltext from Unpaywall -->
+      <step>
+        <heading>submit.progressbar.unpaywall</heading>
+        <processing-class>org.dspace.app.cris.submit.step.UnpaywallStep</processing-class>
+        <workflow-editable>true</workflow-editable>
+      </step>																										
 
 	  <!-- Step 4 auskommentiert fuer Sammlung Universitaetsbibliografie; A.G., 24.05.2018  -->
       <!--Step 4 will be to Upload the item -->

--- a/dspace/config/modules/unpaywall.cfg
+++ b/dspace/config/modules/unpaywall.cfg
@@ -20,3 +20,6 @@ script.authors_email_template.name = unpaywall_authors_alert
 
 #the name of the administrators email template file in [dspace install folder]/config/emails
 script.administrators_email_template.name = unpaywall_administrators_alert
+
+#the max number of items to display in the notification mail
+mail.item.limit = 25


### PR DESCRIPTION
Added improvement to limit the number of record in the body of the email to 25; the file attached will contain all records;
added fix on unpaywall.submit.import.enabled to build.properties 
