### PR TITLE
DOI-Filter: assign DOIs only to items with bitstreams

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/logic/DefaultFilter.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/DefaultFilter.java
@@ -1,0 +1,35 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+/**
+ * The default filter, a very simple implementation of Filter / LogicalStatement
+ * The idea is to have this as a wrapper / root class for all logical operations, so it takes a single
+ * statement as a property (unlike an operator) and takes no parameters (unlike a condition)
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class DefaultFilter implements Filter {
+    private LogicalStatement statement;
+
+    // be aware that this is singular not plural. A filter can have one substatement only.
+    public void setStatement(LogicalStatement statement) {
+        this.statement = statement;
+    }
+
+    private static Logger log = Logger.getLogger(Filter.class);
+
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+        return this.statement.getResult(context, item);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/Filter.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/Filter.java
@@ -1,0 +1,31 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic;
+
+import java.sql.SQLException;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+/**
+ * The interface for Filter currently doesn't add anything to LogicalStatement but inherits from it
+ * just to keep naming / reflection clean, and in case Filters should do anything additional in future.
+ * We need this as filters have to be specified in the spring configuration (item-filters.xml).
+ * Filters are the top level elements of the logic. Only logical statements that implement this interface
+ * are allowed to be the root element of a spring configuration (item-filters.xml) of this logic framework.
+ * A filter is just helping to differentiate between logical statement that can be used as root elements and
+ * logical statement that shouldn't be use as root element. A filter may contain only one substatement.
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ * @see org.dspace.content.logic.DefaultFilter
+ */
+public interface Filter extends LogicalStatement {
+    Boolean getResult(Context context, Item item) throws LogicalStatementException;
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/LogicalStatement.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/LogicalStatement.java
@@ -1,0 +1,24 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic;
+
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+
+/**
+ * The base interface used by all logic classes: all operators and conditions are logical statements.
+ * All statements must accept an Item object and return a boolean result.
+ * The philosophy is that because Filter, Condition, Operator classes implement getResult(), they can all be
+ * used as sub-statements in other Filters and Operators.
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public interface LogicalStatement {
+    Boolean getResult(Context context, Item item) throws LogicalStatementException;
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/LogicalStatementException.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/LogicalStatementException.java
@@ -1,0 +1,32 @@
+package org.dspace.content.logic;
+
+/**
+ * Exception for errors encountered while evaluating logical statements
+ * defined as spring beans.
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class LogicalStatementException extends Exception {
+
+    public LogicalStatementException()
+    {
+        super();
+    }
+
+    public LogicalStatementException(String s, Throwable t)
+    {
+        super(s, t);
+    }
+
+    public LogicalStatementException(String s)
+    {
+        super(s);
+    }
+
+    public LogicalStatementException(Throwable t)
+    {
+        super(t);
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/TestLogicRunner.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/TestLogicRunner.java
@@ -1,0 +1,132 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.PosixParser;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.ItemIterator;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.handle.HandleManager;
+import org.dspace.utils.DSpace;
+
+/**
+ * A command-line runner used for testing a logical filter against an item, or all items
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class TestLogicRunner {
+
+    public static void main(String args[]) throws SQLException {
+
+        System.out.println("Starting impl of main() test spring logic item filter");
+
+        // initlize options
+        Options options = new Options();
+
+        options.addOption("h", "help", false, "Help");
+        options.addOption("l", "list", false, "List filters");
+        options.addOption("f", "filter", true, "Use filter <filter>");
+        options.addOption("i","item", true, "Run filter over item <handle>");
+        options.addOption("a","all", false, "Run filter over all items");
+
+        // initialize parser
+        CommandLineParser parser = new PosixParser();
+        CommandLine line = null;
+        HelpFormatter helpformater = new HelpFormatter();
+
+        try
+        {
+            line = parser.parse(options, args);
+        }
+        catch (ParseException ex)
+        {
+            System.out.println(ex.getMessage());
+            System.exit(1);
+        }
+
+        if(line.hasOption("help")) {
+            helpformater.printHelp("\nTest the DSpace logical item filters\n", options);
+            System.exit(0);
+        }
+
+        // Create a context
+        Context c = new Context();
+
+        // Get 5.x service manager
+        DSpace dspace = new DSpace();
+        org.dspace.kernel.ServiceManager manager = dspace.getServiceManager();
+
+        if(line.hasOption("list")) {
+            // Lit filters and exit
+            List<Filter> filters = manager.getServicesByType(Filter.class);
+            for(Filter filter : filters) {
+                System.out.println(filter.getClass().toString());
+            }
+            System.out.println("See item-filters.xml spring config for filter names");
+            System.exit(0);
+        }
+
+        Filter filter;
+
+        if(line.hasOption("filter")) {
+            String filterName = line.getOptionValue("filter");
+            filter = manager.getServiceByName(filterName, Filter.class);
+            if (filter == null) {
+                System.out.println("Error loading filter: " + filterName);
+                System.exit(1);
+            }
+
+            if (line.hasOption("item")) {
+                String handle = line.getOptionValue("item");
+
+                try {
+                    DSpaceObject dso = HandleManager.resolveToObject(c, handle);
+                    if (Constants.typeText[dso.getType()].equals("ITEM")) {
+                        Item item = (Item) dso;
+                        System.out.println(filter.getResult(c, item).toString());
+                    } else {
+                        System.out.println(handle + " is not an ITEM");
+                    }
+                } catch(SQLException|LogicalStatementException e) {
+                    System.out.println("Error encountered processing item " + handle + ": " + e.getMessage());
+                }
+
+            }
+            else if(line.hasOption("all")) {
+                try {
+                    ItemIterator itemIterator = Item.findAll(c);
+
+                    while (itemIterator.hasNext()) {
+                        Item i = itemIterator.next();
+                        System.out.println("Testing '" + filter + "' on item " + i.getHandle() + " ('" + i.getName() + "')");
+                        System.out.println(filter.getResult(c, i).toString());
+
+                    }
+                } catch(SQLException|LogicalStatementException e) {
+                    System.out.println("Error encountered processing items: " + e.getMessage());
+                }
+            }
+            else {
+                helpformater.printHelp("\nTest the DSpace logical item filters\n", options);
+            }
+        }
+
+    }
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/AbstractCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/AbstractCondition.java
@@ -1,0 +1,50 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.condition;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Abstract class for conditions, to implement the basic getter and setter parameters
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public abstract class AbstractCondition implements Condition {
+    private Map<String, Object> parameters = new HashMap<>();
+
+    @Override
+    public Map<String, Object> getParameters() throws LogicalStatementException {
+        return this.parameters;
+    }
+    @Override
+    public void setParameters(Map<String, Object> parameters) throws LogicalStatementException {
+        this.parameters = parameters;
+    }
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+        if(item == null) {
+            throw new LogicalStatementException("Item is null");
+        }
+        if(context == null) {
+            throw new LogicalStatementException("Context is null");
+        }
+        if(this.parameters == null) {
+            throw new LogicalStatementException("Parameters are null");
+        }
+        return true;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/BitstreamCountCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/BitstreamCountCondition.java
@@ -1,0 +1,84 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.condition;
+
+import java.sql.SQLException;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * A condition to evaluate an item based on how many bitstreams it has in a particular bundle
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class BitstreamCountCondition extends AbstractCondition {
+
+    private static Logger log = Logger.getLogger(BitstreamCountCondition.class);
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+
+        // This super call just throws some useful exceptions if required objects are null
+        super.getResult(context, item);
+
+        Integer min = -1;
+        if (getParameters().get("min") != null) {
+            min = Integer.parseInt((String)getParameters().get("min"));
+        }
+        
+        Integer max = -1;
+        if (getParameters().get("max") != null)
+        {
+            max = Integer.parseInt((String)getParameters().get("max"));
+        }
+        
+        String bundleName = (String)getParameters().get("bundle");
+        
+        if (min < 0 && max < 0) {
+            throw new LogicalStatementException("Either min or max parameter must be 0 or bigger.");
+        }
+
+        Bundle[] bundles;
+        int count = 0;
+
+        try {
+            if (bundleName != null) {
+                bundles = item.getBundles(bundleName);
+            } else {
+                bundles = item.getBundles();
+            }
+
+            for (Bundle bundle : bundles) {
+                count += bundle.getBitstreams().length;
+            }
+        } catch(SQLException e) {
+            log.error("Failed to inspect item bundles due to SQL error: " + e.getMessage());
+            throw new LogicalStatementException(e);
+        }
+
+        log.debug("logic for " + item.getHandle() + ": min: " + min + ", max: " + max
+            + ", bundle: " + bundleName + ", final count: " + count);
+
+        if (min < 0)
+        {
+            return (count <= max);
+        }
+        
+        if (max < 0)
+        {
+            return (count >= min);
+        }
+        
+        return (count <= max && count >= min);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/Condition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/Condition.java
@@ -1,0 +1,30 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.condition;
+
+import java.util.Map;
+
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatement;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * The Condition interface
+ *
+ * A condition is one logical statement testing an item for any idea. A condition is always a logical statements. An
+ * operator is not a condition but also a logical statement.
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public interface Condition extends LogicalStatement {
+    void setParameters(Map<String, Object> parameters) throws LogicalStatementException;
+    Map<String, Object> getParameters() throws LogicalStatementException;
+    Boolean getResult(Context context, Item item) throws LogicalStatementException;
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/InCollectionCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/InCollectionCondition.java
@@ -1,0 +1,52 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.condition;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * A condition that accepts a list of collection handles and returns true
+ * if the item belongs to any of them.
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class InCollectionCondition extends AbstractCondition {
+    private static Logger log = Logger.getLogger(InCollectionCondition.class);
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+
+        try {
+            List<String> collectionHandles = (List<String>) getParameters().get("collections");
+            Collection[] itemCollections = item.getCollections();
+
+            for (Collection collection : itemCollections) {
+                if (collectionHandles.contains(collection.getHandle())) {
+                    log.debug("item " + item.getHandle() + " is in collection "
+                        + collection.getHandle() + ", returning true");
+                    return true;
+                }
+            }
+        } catch(SQLException e) {
+            log.error("Encountered SQL error inspecting item collections: " + e.getMessage());
+            throw new LogicalStatementException(e);
+        }
+
+        log.debug("item " + item.getHandle() + " not found in the passed collection handle list");
+
+        return false;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/InCommunityCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/InCommunityCondition.java
@@ -1,0 +1,52 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.condition;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * A condition that accepts a list of community handles and returns true
+ * if the item belongs to any of them.
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class InCommunityCondition extends AbstractCondition {
+    private static Logger log = Logger.getLogger(InCommunityCondition.class);
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+
+        List<String> communityHandles = (List<String>)getParameters().get("communities");
+        try {
+            Collection[] itemCollections = item.getCollections();
+
+            for (Collection collection : itemCollections) {
+                Community[] communities = collection.getCommunities();
+                for (Community community : communities) {
+                    if (communityHandles.contains(community.getHandle())) {
+                        return true;
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            log.error(e.getMessage());
+            throw new LogicalStatementException(e);
+        }
+
+        return false;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/IsWithdrawnCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/IsWithdrawnCondition.java
@@ -1,0 +1,29 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.condition;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * A condition that returns true if the item is withdrawn
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class IsWithdrawnCondition extends AbstractCondition {
+    private static Logger log = Logger.getLogger(IsWithdrawnCondition.class);
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+        log.debug("Result of isWithdrawn is " + item.isWithdrawn());
+        return item.isWithdrawn();
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/MetadataValueMatchCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/MetadataValueMatchCondition.java
@@ -1,0 +1,57 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.condition;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * A condition that returns true if a pattern (regex) matches any value
+ * in a given metadata field
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class MetadataValueMatchCondition extends AbstractCondition {
+
+    private static Logger log = Logger.getLogger(MetadataValueMatchCondition.class);
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+        String field = (String)getParameters().get("field");
+        if(field == null) {
+            return false;
+        }
+
+        String[] fieldParts = field.split("\\.");
+        String schema = (fieldParts.length > 0 ? fieldParts[0] : null);
+        String element = (fieldParts.length > 1 ? fieldParts[1] : null);
+        String qualifier = (fieldParts.length > 2 ? fieldParts[2] : null);
+
+        Metadatum[] metadata = item.getMetadata(schema, element, qualifier, Item.ANY);
+        for (Metadatum metadatum : metadata) {
+            if(getParameters().get("pattern") instanceof String) {
+                String pattern = (String)getParameters().get("pattern");
+                log.debug("logic for " + item.getHandle() + ": pattern passed is " + pattern
+                    + ", checking value " + metadatum.value);
+                Pattern p = Pattern.compile(pattern);
+                Matcher m = p.matcher(metadatum.value);
+                if(m.find()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/MetadataValuesMatchCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/MetadataValuesMatchCondition.java
@@ -1,0 +1,65 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.condition;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.log4j.Logger;
+import org.dspace.content.Item;
+import org.dspace.content.Metadatum;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * A condition that returns true if any pattern in a list of patterns matches any value
+ * in a given metadata field
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class MetadataValuesMatchCondition extends AbstractCondition {
+
+    private static Logger log = Logger.getLogger(MetadataValuesMatchCondition.class);
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+        String field = (String)getParameters().get("field");
+        if(field == null) {
+            return false;
+        }
+
+        String[] fieldParts = field.split("\\.");
+        String schema = (fieldParts.length > 0 ? fieldParts[0] : null);
+        String element = (fieldParts.length > 1 ? fieldParts[1] : null);
+        String qualifier = (fieldParts.length > 2 ? fieldParts[2] : null);
+
+        Metadatum[] metadata = item.getMetadata(schema, element, qualifier, Item.ANY);
+        for (Metadatum metadatum : metadata) {
+            if(getParameters().get("patterns") instanceof List) {
+                List<String> patternList = (List<String>)getParameters().get("patterns");
+                // If the list is empty, just return true and log error?
+                log.error("No patterns were passed for metadata value matching, defaulting to 'true'");
+                if(patternList == null) {
+                    return true;
+                }
+                for (String pattern : patternList) {
+                    log.debug("logic for " + item.getHandle() + ": pattern passed is " + pattern
+                        + ", checking value " + metadatum.value);
+                    Pattern p = Pattern.compile(pattern);
+                    Matcher m = p.matcher(metadatum.value);
+                    if(m.find()) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/condition/ReadableByGroupCondition.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/condition/ReadableByGroupCondition.java
@@ -1,0 +1,53 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.condition;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.dspace.authorize.AuthorizeManager;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+
+/**
+ * A condition that accepts a group and action parameter and returns true if the group
+ * can perform the action on a given item
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class ReadableByGroupCondition extends AbstractCondition {
+    private static Logger log = Logger.getLogger(ReadableByGroupCondition.class);
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+
+        String group = (String)getParameters().get("group");
+        String action = (String)getParameters().get("action");
+
+        try {
+            List<ResourcePolicy> policies =
+                AuthorizeManager.getPoliciesActionFilter(context, item, Constants.getActionID(action));
+            for (ResourcePolicy policy : policies) {
+                if (policy.getGroup().getName().equals(group)) {
+                    return true;
+                }
+            }
+        } catch(SQLException e) {
+            log.error("Error trying to read policies for " + item.getHandle() + ": " + e.getMessage());
+            throw new LogicalStatementException(e);
+        }
+        log.debug("item " + item.getHandle() + " not readable by anonymous group");
+
+        return false;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/operator/AbstractOperator.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/operator/AbstractOperator.java
@@ -1,0 +1,46 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.operator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatement;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * Abstract class for an operator
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public abstract class AbstractOperator implements LogicalStatement {
+
+    private List<LogicalStatement> statements = new ArrayList<>();
+
+    public List<LogicalStatement> getStatements() {
+        return statements;
+    }
+
+    public void setStatements(List<LogicalStatement> statements) {
+        this.statements = statements;
+    }
+
+    AbstractOperator() {}
+
+    AbstractOperator(List<LogicalStatement> statements) {
+        this.statements = statements;
+    }
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+        return false;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/operator/And.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/operator/And.java
@@ -1,0 +1,44 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.operator;
+
+import java.util.List;
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatement;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * An operator that implements AND by evaluating sub-statements and only returning
+ * true if all sub-statements return true
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class And extends AbstractOperator {
+
+    And() {
+        super();
+    }
+
+    And(List<LogicalStatement> statements) {
+        super(statements);
+    }
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+
+        for (LogicalStatement statement : getStatements()) {
+            if(!statement.getResult(context, item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/operator/Nand.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/operator/Nand.java
@@ -1,0 +1,37 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.operator;
+
+import java.util.List;
+
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatement;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * An operator that implements NAND by negating an AND operation
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class Nand extends AbstractOperator {
+
+    Nand() {
+        super();
+    }
+
+    Nand(List<LogicalStatement> statements) {
+        super(statements);
+    }
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+        return !(new And(getStatements()).getResult(context, item));
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/operator/Nor.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/operator/Nor.java
@@ -1,0 +1,37 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.operator;
+
+import java.util.List;
+
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatement;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * An operator that implements NIR by negating an OR operation
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class Nor extends AbstractOperator {
+
+    Nor() {
+        super();
+    }
+
+    Nor(List<LogicalStatement> statements) {
+        super(statements);
+    }
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+        return !(new Or(getStatements()).getResult(context, item));
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/operator/Not.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/operator/Not.java
@@ -1,0 +1,46 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.operator;
+
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatement;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * An operator that implements NOT by simply negating a statement
+ * Note that this operator doesn't actually implement the 'AbstractOperator' interface because
+ * we only want one sub-statement. So it's actually just a simple implementation of LogicalStatement.
+ * Not can have one sub-statement only, while and, or, nor, ... can have multiple sub-statements.
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class Not implements LogicalStatement {
+
+    private LogicalStatement statement;
+
+    public LogicalStatement getStatements() {
+        return statement;
+    }
+
+    public void setStatements(LogicalStatement statement) {
+        this.statement = statement;
+    }
+
+    Not() {}
+
+    Not(LogicalStatement statement) {
+        this.statement = statement;
+    }
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+        return !statement.getResult(context, item);
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/logic/operator/Or.java
+++ b/dspace-api/src/main/java/org/dspace/content/logic/operator/Or.java
@@ -1,0 +1,45 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.logic.operator;
+
+import java.util.List;
+
+import org.dspace.content.Item;
+import org.dspace.content.logic.LogicalStatement;
+import org.dspace.content.logic.LogicalStatementException;
+import org.dspace.core.Context;
+
+/**
+ * An operator that implements OR by evaluating sub-statements and returns
+ * true if one or more sub-statements return true
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public class Or extends AbstractOperator {
+
+    Or() {
+        super();
+    }
+
+    Or(List<LogicalStatement> statements) {
+        super(statements);
+    }
+
+    @Override
+    public Boolean getResult(Context context, Item item) throws LogicalStatementException {
+
+        for (LogicalStatement statement : getStatements()) {
+            if(statement.getResult(context, item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/identifier/DOI.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/DOI.java
@@ -8,10 +8,15 @@
 
 package org.dspace.identifier;
 
-import java.util.Locale;
+import java.sql.SQLException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.dspace.content.DSpaceObject;
+import org.dspace.core.Context;
 import org.dspace.identifier.doi.DOIIdentifierException;
+import org.dspace.storage.rdbms.DatabaseManager;
+import org.dspace.storage.rdbms.TableRow;
 
 /**
  * DOI identifiers.
@@ -100,5 +105,30 @@ public class DOI
         }
         throw new DOIIdentifierException(identifier + "does not seem to be a DOI.",
                 DOIIdentifierException.UNRECOGNIZED);
+    }
+
+    /**
+     * This method should be equivalent to the 6.x services findDOIByDSpaceObject - at least, it is used in the
+     * same places in 5.x code
+     * @param context current user's context
+     * @param dso the DSO to check
+     * @return table row with doi infomration
+     * @throws SQLException
+     */
+    public static TableRow findDOIByDSpaceObject(Context context, DSpaceObject dso) throws DOIIdentifierException {
+        TableRow checkRow = null;
+        try {
+            // The below database operation should be equivalent to the 6.x
+            // "findDOIByDSpaceObject" method
+            String sql = "SELECT * FROM Doi WHERE resource_type_id = ? " +
+                "AND resource_id = ? AND ((status != ? AND status != ?) OR status IS NULL)";
+            checkRow = DatabaseManager.querySingleTable(context, "Doi", sql,
+                dso.getType(), dso.getID(), DOIIdentifierProvider.TO_BE_DELETED,
+                DOIIdentifierProvider.DELETED);
+        } catch(SQLException e) {
+            throw new DOIIdentifierException(e);
+        }
+
+        return checkRow;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/identifier/FilteredIdentifierProvider.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/FilteredIdentifierProvider.java
@@ -1,0 +1,55 @@
+package org.dspace.identifier;
+
+import java.sql.SQLException;
+
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.logic.Filter;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Required;
+
+/**
+ * This abstract class adds extra method signatures so that implementing IdentifierProviders can
+ * handle "skip filter" booleans, so that any configured filters can be skipped and DOI registration forced.
+ *
+ * @author Kim Shepherd
+ * @version $Revision$
+ */
+public abstract class FilteredIdentifierProvider extends IdentifierProvider {
+
+    protected Filter filterService;
+
+    public FilteredIdentifierProvider() {
+
+    }
+
+    @Autowired
+    public FilteredIdentifierProvider(Filter filterService) {
+        this.filterService = filterService;
+    }
+
+    @Autowired
+    public void setFilterService(Filter filterService) {
+        this.filterService = filterService;
+    }
+
+    @Autowired
+    public Filter getFilterService() {
+        return this.filterService;
+    }
+
+    public abstract String register(Context context, DSpaceObject dso, Boolean skipFilter)
+        throws IdentifierException;
+
+    public abstract void register(Context context, DSpaceObject dso, String identifier, Boolean skipFilter)
+        throws IdentifierException;
+
+    public abstract void reserve(Context context, DSpaceObject dso, String identifier, Boolean skipFilter)
+        throws IdentifierException, IllegalArgumentException, SQLException;
+
+    public abstract String mint(Context context, DSpaceObject dso, Boolean skipFilter) throws IdentifierException;
+
+    public abstract Boolean canMint(Context context, DSpaceObject dso) throws IdentifierException;
+
+
+}

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/DOIIdentifierNotApplicableException.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/DOIIdentifierNotApplicableException.java
@@ -1,0 +1,27 @@
+package org.dspace.identifier.doi;
+
+/**
+ *
+ * Thrown when an identifier should not be applied to an item, eg. when it has been filtered by an item filter
+ *
+ *
+ * @author Kim Shepherd
+ */
+public class DOIIdentifierNotApplicableException extends DOIIdentifierException {
+
+    public DOIIdentifierNotApplicableException() {
+        super();
+    }
+
+    public DOIIdentifierNotApplicableException(String message) {
+        super(message);
+    }
+
+    public DOIIdentifierNotApplicableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DOIIdentifierNotApplicableException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/dspace-api/src/main/resources/Messages.properties
+++ b/dspace-api/src/main/resources/Messages.properties
@@ -5415,3 +5415,9 @@ jsp.display-item.unpaywall.tooltip = Open PDF on Unpaywall
 jsp.submit.choose-file.unpaywall.title = The system is integrated with Unpaywall to retrieve open access fulltext.
 jsp.submit.choose-file.unpaywall.tooltip = Import fulltext from Unpaywall
 jsp.submit.choose-file.unpaywall.button = Import from
+
+###
+# Additions for DOI filter
+###
+jsp.tools.edit-item-form.form.button.register-doi = Register DOI
+jsp.tools.edit-item-form.doi-registered-note = A DOI has been registered for this item

--- a/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
+++ b/dspace-jspui/src/main/webapp/static/css/bootstrap/dspace-theme.css
@@ -1,5 +1,4 @@
-/
-**
+/**
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree and available online at
@@ -7,8 +6,7 @@
  * http://www.dspace.org/license/
  */
 
-/
-**
+/**
 * Farbe geändert in .brand h4 auf magenta; A. Groneberg, 26.10.2017
 */
 .banner img {background-color: #FFFFFF;padding:15px;margin-top:20px;}

--- a/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
+++ b/dspace-jspui/src/main/webapp/tools/edit-item-form.jsp
@@ -66,7 +66,12 @@
     // Is the logged in user an admin of the item
     Boolean itemAdmin = (Boolean)request.getAttribute("admin_button");
     boolean isItemAdmin = (itemAdmin == null ? false : itemAdmin.booleanValue());
-    
+
+    Boolean registerDoiButton = (Boolean)request.getAttribute("register_doi_button");
+    boolean canRegisterDoi = (registerDoiButton == null ? false : registerDoiButton.booleanValue());
+
+    String registeredDOI = (String)request.getAttribute("registered-doi");
+
     Boolean policy = (Boolean)request.getAttribute("policy_button");
     boolean bPolicy = (policy == null ? false : policy.booleanValue());
     
@@ -217,6 +222,18 @@
     You are responsible for entering the data in the correct format.
     If you are not sure what the format is, please do NOT make changes.</strong></p> --%>
     <p class="alert alert-danger"><strong><fmt:message key="jsp.tools.edit-item-form.note"/></strong></p>
+
+    <%
+
+        if(registeredDOI != null) {
+        %>
+              <p class="alert alert-success"><strong><fmt:message key="jsp.tools.edit-item-form.doi-registered-note"/>: <%= registeredDOI %></strong></p>
+        <%
+        }
+
+    %>
+
+
 
 	<div class="row">
 	<div class="col-md-9">
@@ -389,8 +406,21 @@
 									name="submit_item_select"
 									value="<fmt:message key="jsp.tools.edit-item-form.form.button.curate"/>" />
 							</form>
+        <% if(canRegisterDoi) { %>
+<%-- ===========================================================
+     Register DOI for Item
+     =========================================================== --%>
+                <form method="post"
+                      action="<%= request.getContextPath() %>/tools/edit-item">
+                    <input type="hidden" name="item_id" value="<%= item.getID() %>" />
+                    <input type="hidden" name="action" value="<%= EditItemServlet.REGISTER_DOI %>" />
+                    <input class="btn btn-default col-md-12" type="submit"
+                           name="submit_item_select"
+                           value="<fmt:message key="jsp.tools.edit-item-form.form.button.register-doi"/>" />
+                </form>
 					<%
-						}
+	    }
+    }
 					%>
     	    </div>
         </div>

--- a/dspace/config/spring/api/identifier-service.xml
+++ b/dspace/config/spring/api/identifier-service.xml
@@ -35,6 +35,9 @@
 
     <!-- In order to mint DOIs with DSpace, get an agreement with a DOI registration
          agency,  take a look into dspace.cfg, and uncomment this.
+
+         An optional 'filterService' property may be included with a reference to a bean name
+         as configured in item-filters.xml
     -->
     <bean id="org.dspace.identifier.DOIIdentifierProvider"
         class="org.dspace.identifier.DOIIdentifierProvider"
@@ -43,6 +46,8 @@
             ref="org.dspace.services.ConfigurationService" />
         <property name="DOIConnector"
             ref="org.dspace.identifier.doi.DOIConnector" />
+        <!-- Configure the "has_bistream_filter" for DOI registration use -->
+        <property name="filterService" ref="has_bitstream_filter"/>
     </bean>
     
     

--- a/dspace/config/spring/api/item-filters.xml
+++ b/dspace/config/spring/api/item-filters.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+           http://www.springframework.org/schema/context
+           http://www.springframework.org/schema/context/spring-context-2.5.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+   >
+
+    <context:annotation-config /> <!-- allows us to use spring annotations in beans -->
+
+    <!-- DEFINE CONDITIONS
+        Define condition beans below for use as sub-statements in operator and filter beans
+    -->
+
+    <!-- Item is publicly accessible -->
+    <bean id="item_is_public_condition"
+          class="org.dspace.content.logic.condition.ReadableByGroupCondition">
+        <property name="parameters">
+            <map>
+                <entry key="group" value="Anonymous" />
+                <entry key="action" value="READ" />
+            </map>
+        </property>
+    </bean>
+
+    <!-- Has at least one bitstream -->
+    <bean id="has_bitstream_condition"
+          class="org.dspace.content.logic.condition.BitstreamCountCondition">
+        <property name="parameters">
+            <map>
+                <entry key="bundle" value="ORIGINAL"/>
+                <entry key="min" value="1"/>
+            </map>
+        </property>
+    </bean>
+
+    <!-- DEFINE OPERATORS -->
+
+    <!-- DEFINE FILTERS -->
+
+    <!-- A simple filter just implementing the "has at least one bitstream" condition -->
+    <bean id="has_bitstream_filter" class="org.dspace.content.logic.DefaultFilter">
+        <property name="statement">
+            <ref bean="has_bitstream_condition"/>
+        </property>
+    </bean>
+
+</beans>


### PR DESCRIPTION
Assign DOIs only to items that contain a bitstream in the bundle ORIGINAL.

This will not work if the plugin to show DOIs during submission is in place. In this case it would still prevent items without bitstreams coming via an import to get a DOI assigned.